### PR TITLE
Fix invalid syntax error

### DIFF
--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -70,7 +70,7 @@ class ControlSystem(EvohomeBase):
             yield {'thermostat': 'DOMESTIC_HOT_WATER',
                     'id': dhw['dhwId'],
                     'name': '',
-                    'temp': dhw['temperatureStatus']['temperature']
+                    'temp': dhw['temperatureStatus']['temperature'],
                     'setpoint': ''
                   }
 


### PR DESCRIPTION
Missing comma in dict creation causing syntax error
