### PR TITLE
fix ControlSystem.temperatures() to handle unavailable temperatures

### DIFF
--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -74,12 +74,15 @@ class ControlSystem(EvohomeBase):
                   }
 
         for zone in self._zones:
-            yield {'thermostat': 'EMEA_ZONE',
-                    'id': zone.zoneId,
-                    'name': zone.name,
-                    'temp': zone.temperatureStatus['temperature'],
-                    'setpoint': zone.heatSetpointStatus['targetTemperature']
-                  }
+            z = {'thermostat': 'EMEA_ZONE',
+                 'id': zone.zoneId,
+                 'name': zone.name,
+                 'temp': None,
+                 'setpoint': zone.heatSetpointStatus['targetTemperature']
+                }
+            if zone.temperatureStatus['isAvailable']:
+                z['temp'] = zone.temperatureStatus['temperature']
+            yield z
 
     def zone_schedules_backup(self, filename):
         print("Backing up zone schedule to: %s" % (filename))


### PR DESCRIPTION
I was getting an exception iterating over client.temperatures():

{'temp': 19.0, 'setpoint': 15.0, 'thermostat': 'EMEA_ZONE', 'name': u'Sitting Room', 'id': u'899097'}
{'temp': 18.0, 'setpoint': 15.0, 'thermostat': 'EMEA_ZONE', 'name': u'Drawing Room', 'id': u'899098'}
Traceback (most recent call last):
  File "./test.py", line 10, in <module>
    for dev in client.temperatures():
  File "/home/ramcq/src/evohome-client/evohomeclient2/controlsystem.py", line 80, in temperatures
    'temp': zone.temperatureStatus['temperature'],
KeyError: 'temperature'

It's because one of my zones is missing the sensor, so it has a setpoint but zone.temperatureStatus['isAvailable'] is FALSE and so there is no 'temperature' key. I fixed it by returning 'temp':None in this ControlSystem.temperatures() but I don't know if it's a good API.