### PR TITLE
Expose Quick Action, 'AutoWithReset': resets zones to 'FollowSchedule'

### DIFF
--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -105,6 +105,9 @@ class EvohomeClient(EvohomeBase):
     def set_status_normal(self):
         return self._get_single_heating_system().set_status_normal()
 
+    def set_status_reset(self):
+        return self._get_single_heating_system().set_status_reset()
+
     def set_status_custom(self, until=None):
         return self._get_single_heating_system().set_status_custom(until)
 

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -47,6 +47,9 @@ class ControlSystem(EvohomeBase):
     def set_status_normal(self):
         self._set_status("Auto")
 
+    def set_status_reset(self):
+        self._set_status("AutoWithReset")
+
     def set_status_custom(self, until=None):
         self._set_status("Custom", until)
 


### PR DESCRIPTION
If you execute this code, you will see a 'Quick Action' (system mode) that is not exposed in the controller UI.  It is a useful mode, because it sets all zones to 'FollowSchedule'.
```
from evohomeclient2 import EvohomeClient as EvohomeClient
client = EvohomeClient(username, password)

for mode in client.installation_info[0]['gateways'][0]['temperatureControlSystems'][0]['allowedSystemModes']:
  if mode['systemMode'] == 'AutoWithReset':
    print(mode)
```

Until, I have been calling this api by `self.client._get_single_heating_system._set_status(5)`, but this exposes the api call more directly.

It shouldn't break existing users of **evohome-client**, as it is just adding an api.