### PR TITLE
Expose the date/time that the v2 access token expires

### DIFF
--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 import requests
 import json
 import codecs
+from datetime import datetime, timedelta
 from .location import Location
 from .base import EvohomeBase
 
@@ -12,7 +13,6 @@ class EvohomeClient(EvohomeBase):
         self.username = username
         self.password = password
 
-        self.access_token = None
         self.locations = []
 
         self._login()
@@ -48,6 +48,9 @@ class EvohomeClient(EvohomeBase):
         
         
     def _login(self):
+        self._access_token = None
+        self.access_token_expires = None
+
         url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
         headers = {
             'Authorization':	'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
@@ -67,6 +70,8 @@ class EvohomeClient(EvohomeBase):
         }
         r = requests.post(url, data=data, headers=headers)
         self.access_token = self._convert(r.text)['access_token']
+        self.access_token_expires = datetime.now() \
+            + timedelta(seconds = self._convert(r.text)['expires_in'])
         self.headers = {
             'Authorization': 'bearer ' + self.access_token,
             'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'


### PR DESCRIPTION
The v2 api uses access tokens.  0.2.5 seems to have a 60 min timeout, whilst 0.2.6 has a 30 min timeout!  

In any case, the code utilising the evohome-client needs to use `_login()` to obtain another access token before the existing token expires.  The PR exposes the date/time that the access token expires via `client.access_token_expires`.  It also moves the initialization of `client.access_token` from `__init__()` to `_login()`.

This change is much simpler than trying to deal with refresh tokens.

This PR should not affect existing users of this library.