### PR TITLE
Auto renew - add r.raise_for_status() after r = requests...

### DIFF
--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -46,7 +46,7 @@ class EvohomeClient(EvohomeBase):
         
     def _basic_login(self):
         self.access_token = None
-#       self.locations = []
+        self.locations = []
 
         url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
         headers = {
@@ -66,6 +66,9 @@ class EvohomeClient(EvohomeBase):
             'Connection':	'Keep-Alive'
         }
         r = requests.post(url, data=data, headers=headers)
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
 
         data = self._convert(r.text)
         self.access_token = data['access_token']
@@ -90,11 +93,17 @@ class EvohomeClient(EvohomeBase):
     def user_account(self):
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount', headers=self.headers())
 
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
+
         self.account_info = self._convert(r.text)
         return self.account_info
 
     def installation(self):
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=%s&includeTemperatureControlSystems=True' % self.account_info['userId'], headers=self.headers())
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
 
         self.installation_info = self._convert(r.text)
         self.system_id = self.installation_info[0]['gateways'][0]['temperatureControlSystems'][0]['systemId']
@@ -108,10 +117,18 @@ class EvohomeClient(EvohomeBase):
     def full_installation(self, location=None):
         location = self._get_location(location)
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/installationInfo?includeTemperatureControlSystems=True' % location, headers=self.headers())
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
+
         return self._convert(r.text)
 
     def gateway(self):
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/gateway', headers=self.headers())
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
+
         return self._convert(r.text)
 
     def set_status_normal(self):

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -46,7 +46,7 @@ class EvohomeClient(EvohomeBase):
         
     def _basic_login(self):
         self.access_token = None
-        self.locations = []
+#       self.locations = []
 
         url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
         headers = {

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -46,13 +46,12 @@ class EvohomeClient(EvohomeBase):
         
     def _basic_login(self):
         self.access_token = None
-#       self.locations = []
+        self.access_token_expires = None
 
         url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
         headers = {
             'Authorization':	'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
             'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
-
         }
         data = {
             'Content-Type':	'application/x-www-form-urlencoded; charset=utf-8',
@@ -72,7 +71,6 @@ class EvohomeClient(EvohomeBase):
 
         data = self._convert(r.text)
         self.access_token = data['access_token']
-
         self.access_token_expires = datetime.now() + timedelta(seconds = data['expires_in'])
 
         self._headers = {
@@ -91,6 +89,7 @@ class EvohomeClient(EvohomeBase):
         return self._headers
 
     def user_account(self):
+        self.account_info = None
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount', headers=self.headers())
 
         if r.status_code != requests.codes.ok:
@@ -100,6 +99,7 @@ class EvohomeClient(EvohomeBase):
         return self.account_info
 
     def installation(self):
+        self.locations = []
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=%s&includeTemperatureControlSystems=True' % self.account_info['userId'], headers=self.headers())
 
         if r.status_code != requests.codes.ok:
@@ -108,7 +108,6 @@ class EvohomeClient(EvohomeBase):
         self.installation_info = self._convert(r.text)
         self.system_id = self.installation_info[0]['gateways'][0]['temperatureControlSystems'][0]['systemId']
 
-        self.locations = []
         for loc_data in self.installation_info:
             self.locations.append(Location(self, loc_data))
 

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -42,7 +42,11 @@ class ControlSystem(EvohomeBase):
             data = {"SystemMode":mode,"TimeUntil":None,"Permanent":True}
         else:
             data = {"SystemMode":mode,"TimeUntil":"%sT00:00:00Z" % until.strftime('%Y-%m-%d'),"Permanent":False}
+
         r = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureControlSystem/%s/mode' % self.systemId, data=json.dumps(data), headers=headers)
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
 
     def set_status_normal(self):
         self._set_status("Auto")

--- a/evohomeclient2/hotwater.py
+++ b/evohomeclient2/hotwater.py
@@ -18,8 +18,10 @@ class HotWater(ZoneBase):
         headers['Content-Type'] = 'application/json'
         url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/domesticHotWater/%s/state' % self.dhwId
 
-        response = requests.put(url, data=json.dumps(data), headers=headers)
+        r = requests.put(url, data=json.dumps(data), headers=headers)
 
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
 
     def set_dhw_on(self, until=None):
         if until is None:

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -2,6 +2,9 @@ from .gateway import Gateway
 from .base import EvohomeBase
 import requests
 
+import logging
+_LOGGER = logging.getLogger(__name__)
+
 class Location(EvohomeBase):
 
     def __init__(self, client, data=None):
@@ -19,7 +22,14 @@ class Location(EvohomeBase):
             self.status()
 
     def status(self):
+        _LOGGER.info("status(), calling: r = requests.get(...)...")
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/status?includeTemperatureControlSystems=True' % self.locationId, headers=self.client.headers())
+        _LOGGER.info("status(), r.status_code: %s", r.status_code)
+        _LOGGER.info("status(): r.text = '%s'", r.text)
+
+        if r.status_code != requests.codes.ok:
+            _LOGGER.info("status(): r.text = '%s'", r.text)
+            r.raise_for_status()
         data = self.client._convert(r.text)
 
         # Now feed into other elements

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -2,9 +2,6 @@ from .gateway import Gateway
 from .base import EvohomeBase
 import requests
 
-import logging
-_LOGGER = logging.getLogger(__name__)
-
 class Location(EvohomeBase):
 
     def __init__(self, client, data=None):
@@ -22,14 +19,11 @@ class Location(EvohomeBase):
             self.status()
 
     def status(self):
-        _LOGGER.info("status(), calling: r = requests.get(...)...")
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/status?includeTemperatureControlSystems=True' % self.locationId, headers=self.client.headers())
-        _LOGGER.info("status(), r.status_code: %s", r.status_code)
-        _LOGGER.info("status(): r.text = '%s'", r.text)
 
         if r.status_code != requests.codes.ok:
-            _LOGGER.info("status(): r.text = '%s'", r.text)
             r.raise_for_status()
+
         data = self.client._convert(r.text)
 
         # Now feed into other elements

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -8,8 +8,10 @@ class ZoneBase(EvohomeBase):
 
     def schedule(self):
         r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' % (self.zone_type, self.zoneId), headers=self.client.headers())
-        # was request ok ?
-        r.raise_for_status()
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
+
         mapping = [
             ('dailySchedules', 'DailySchedules'),
             ('dayOfWeek', 'DayOfWeek'),
@@ -39,6 +41,10 @@ class ZoneBase(EvohomeBase):
         headers = dict(self.client.headers())
         headers['Content-Type'] = 'application/json'
         r = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' % (self.zone_type, self.zoneId), data=zone_info, headers=headers)
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
+
         return self._convert(r.text)
 
 class Zone(ZoneBase):
@@ -61,7 +67,10 @@ class Zone(ZoneBase):
         url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureZone/%s/heatSetpoint' % self.zoneId
         headers = dict(self.client.headers())
         headers['Content-Type'] = 'application/json'
-        response = requests.put(url, json.dumps(data), headers=headers)
+        r = requests.put(url, json.dumps(data), headers=headers)
+
+        if r.status_code != requests.codes.ok:
+            r.raise_for_status()
 
     def cancel_temp_override(self, *args, **kwargs):
         data = {"HeatSetpointValue":0.0,"SetpointMode":"FollowSchedule","TimeUntil":None}


### PR DESCRIPTION
I have added the following after every instance of `r = requests.xxx()`:
```
if r.status_code != requests.codes.ok:
    r.raise_for_status()
```
I feel this is the bare minimum: it might be better to include `r.text` in the `raise_for_status`.

BTW, for consistency, I also changed all `response = requests.xxx` to `r = requests.xxx`.