### PR TITLE
Improve how `headers()` refreshes access tokens

### DIFF
--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -84,7 +84,11 @@ class EvohomeClient(EvohomeBase):
         self.installation()
 
     def headers(self):
-        if datetime.now() > self.access_token_expires - timedelta(seconds = 30):
+        if self.access_token is None or self.access_token_expires is None:
+        # token is invalid
+            self._basic_login()
+        elif datetime.now() > self.access_token_expires - timedelta(seconds = 30):
+        # token has expired
             self._basic_login()
         return self._headers
 


### PR DESCRIPTION
I had the following exceptions (below) that occurred every time I called the **evohome-client** library.  I understood then that it had resolved spontaneously, but now I am not so sure.  In any case it hasn't occurred again (even though I have since added more logging).  

I have no idea what caused the initial problem, but in `_basic_login()`, both `access_token_expires` and `access_token` are set to `None` _before_ being being given values according to the result of the authentication request, via a `request.post()`.  

In my case an exception was thrown in the following fragment of code because `self.access_token_expires` was `None`: (although there is no evidence in my logs that the preceding `r.status_code != requests.codes.ok` was not `True`:
```
if datetime.now() > self.access_token_expires - timedelta(seconds = 30):
    self._basic_login()
TypeError: unsupported operand type(s) for -: 'NoneType' and 'datetime.timedelta'
```
... so, thinking about it, it may be better to change `headers()` to:
```
if self.access_token is None or self.access_token is None:
    self._basic_login()
elif datetime.now() > self.access_token_expires - timedelta(seconds = 30):
    self._basic_login()
```
... otherwise, you'll be stuck in an infinite loop (the 30 min timer cannot ever expire).  In my case I have another timer that would have called `_login()` after a few hours, this cleaning up the mess.

This is a non-breaking change, and I have run this code on my testbed for over 30 mins without error.