### PR TITLE
Big whitespace cleanup via flake8

### DIFF
--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -20,12 +20,13 @@ except ImportError:
 _ver = sys.version_info
 
 #: Python 2.x?
-is_py2=(_ver[0]==2)
+is_py2 = (_ver[0] == 2)
 #: Python 3.x?
-is_py3=(_ver[0]==3)
+is_py3 = (_ver[0] == 3)
+
 
 class EvohomeClient:
-    def __init__(self, username, password, debug = False, user_data = None):
+    def __init__(self, username, password, debug=False, user_data=None):
         self.username = username
         self.password = password
         self.user_data = user_data
@@ -43,7 +44,7 @@ class EvohomeClient:
             logging.getLogger(__name__).setLevel(logging.INFO)
             requests_log.setLevel(logging.INFO)
             requests_log.propagate = False
-    
+
     def _convert(self, object):
         return json.loads(self.reader(object)[0])
 
@@ -60,16 +61,16 @@ class EvohomeClient:
 
             self.headers['sessionId'] = sessionId
 
-            response = requests.get(url,data=json.dumps(self.postdata),headers=self.headers)
+            response = requests.get(url, data=json.dumps(self.postdata), headers=self.headers)
 
             self.full_data = self._convert(response.content)[0]
-            
+
             try:
                 self.location_id = self.full_data['locationID']
-            
+
                 self.devices = {}
                 self.named_devices = {}
-            
+
                 for device in self.full_data['devices']:
                     self.devices[device['deviceID']] = device
                     self.named_devices[device['name']] = device
@@ -80,21 +81,21 @@ class EvohomeClient:
         self._populate_full_data()
         if self.gateway_data is None:
             url = 'https://tccna.honeywell.com/WebAPI/api/gateways?locationId=%s&allData=False' % self.location_id
-            response = requests.get(url, headers = self.headers)
-            
+            response = requests.get(url, headers=self.headers)
+
             self.gateway_data = self._convert(response.content)[0]
 
     def _populate_user_info(self):
         if self.user_data is None:
             url = 'https://tccna.honeywell.com/WebAPI/api/Session'
-            self.postdata = {'Username':self.username,'Password':self.password,'ApplicationId':'91db1612-73fd-4500-91b2-e63b069b185c'}
-            self.headers = {'content-type':'application/json'}
+            self.postdata = {'Username': self.username, 'Password': self.password, 'ApplicationId': '91db1612-73fd-4500-91b2-e63b069b185c'}
+            self.headers = {'content-type': 'application/json'}
 
-            response = requests.post(url,data=json.dumps(self.postdata),headers=self.headers)
+            response = requests.post(url, data=json.dumps(self.postdata), headers=self.headers)
             self.user_data = self._convert(response.content)
-            
+
         return self.user_data
-        
+
     def temperatures(self, force_refresh=False):
         self._populate_full_data(force_refresh)
         for device in self.full_data['devices']:
@@ -102,11 +103,10 @@ class EvohomeClient:
             if 'heatSetpoint' in device['thermostat']['changeableValues']:
                 setPoint = float(device['thermostat']['changeableValues']["heatSetpoint"]["value"])
             yield {'thermostat': device['thermostatModelType'],
-                    'id': device['deviceID'],
-                    'name': device['name'],
-                    'temp': float(device['thermostat']['indoorTemperature']),
-                   'setpoint':setPoint}
-
+                   'id': device['deviceID'],
+                   'name': device['name'],
+                   'temp': float(device['thermostat']['indoorTemperature']),
+                   'setpoint': setPoint}
 
     def get_modes(self, zone):
         self._populate_full_data()
@@ -124,41 +124,41 @@ class EvohomeClient:
         self._populate_full_data()
         url = 'https://tccna.honeywell.com/WebAPI/api/commTasks?commTaskId=%s' % task_id
         response = requests.get(url, headers=self.headers)
-        
+
         return self._convert(response.content)['state']
-    
+
     def _get_task_id(self, response):
         ret = self._convert(response.content)
-        
+
         if isinstance(ret, list):
             task_id = ret[0]['id']
         else:
             task_id = ret['id']
         return task_id
-        
+
     def _set_status(self, status, until=None):
         self._populate_full_data()
         url = 'https://tccna.honeywell.com/WebAPI/api/evoTouchSystems?locationId=%s' % self.location_id
         if until is None:
-            data = {"QuickAction":status,"QuickActionNextTime":None}
+            data = {"QuickAction": status, "QuickActionNextTime": None}
         else:
-            data = {"QuickAction":status,"QuickActionNextTime":"%sT00:00:00Z" % until.strftime('%Y-%m-%d')}
+            data = {"QuickAction": status, "QuickActionNextTime": "%sT00:00:00Z" % until.strftime('%Y-%m-%d')}
         response = requests.put(url, data=json.dumps(data), headers=self.headers)
-        
+
         task_id = self._get_task_id(response)
-        
+
         while self._get_task_status(task_id) != 'Succeeded':
             time.sleep(1)
 
     def set_status_normal(self):
         self._set_status('Auto')
-            
+
     def set_status_custom(self, until=None):
         self._set_status('Custom', until)
 
     def set_status_eco(self, until=None):
         self._set_status('AutoWithEco', until)
-        
+
     def set_status_away(self, until=None):
         self._set_status('Away', until)
 
@@ -171,65 +171,62 @@ class EvohomeClient:
     def _get_device_id(self, zone):
         device = self._get_device(zone)
         return device['deviceID']
-        
+
     def _set_heat_setpoint(self, zone, data):
         self._populate_full_data()
-        
+
         device_id = self._get_device_id(zone)
-        
+
         url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues/heatSetpoint' % device_id
         response = requests.put(url, json.dumps(data), headers=self.headers)
 
         task_id = self._get_task_id(response)
-        
+
         while self._get_task_status(task_id) != 'Succeeded':
             time.sleep(1)
-        
+
     def set_temperature(self, zone, temperature, until=None):
         if until is None:
-            data = {"Value":temperature,"Status":"Hold","NextTime":None}
+            data = {"Value": temperature, "Status": "Hold", "NextTime": None}
         else:
-            data = {"Value":temperature,"Status":"Temporary","NextTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"Value": temperature, "Status": "Temporary", "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_heat_setpoint(zone, data)
-        
-        
+
     def cancel_temp_override(self, zone):
-        data = {"Value":None,"Status":"Scheduled","NextTime":None}
+        data = {"Value": None, "Status": "Scheduled", "NextTime": None}
         self._set_heat_setpoint(zone, data)
-        
+
     def _get_dhw_zone(self):
         for device in self.full_data['devices']:
             if device['thermostatModelType'] == 'DOMESTIC_HOT_WATER':
                 return device['deviceID']
         return None
-        
+
     def _set_dhw(self, data):
         self._populate_full_data()
         url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues' % self._get_dhw_zone()
-        
+
         response = requests.put(url, data=json.dumps(data), headers=self.headers)
-        
+
         task_id = self._get_task_id(response)
-        
+
         while self._get_task_status(task_id) != 'Succeeded':
             time.sleep(1)
-        
+
     def set_dhw_on(self, until=None):
         if until is None:
-            data = {"Mode":"DHWOn","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":None}
+            data = {"Mode": "DHWOn", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": None}
         else:
-            data = {"Mode":"DHWOn","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"Mode": "DHWOn", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_off(self, until=None):
         if until is None:
-            data = {"Mode":"DHWOff","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":None}
+            data = {"Mode": "DHWOff", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": None}
         else:
-            data = {"Mode":"DHWOff","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"Mode": "DHWOff", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
-        
-        
+
     def set_dhw_auto(self):
-        data = {"Mode":None,"SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Scheduled","NextTime":None}
+        data = {"Mode": None, "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Scheduled", "NextTime": None}
         self._set_dhw(data)
- 

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from .location import Location
 from .base import EvohomeBase
 
+
 class EvohomeClient(EvohomeBase):
     def __init__(self, username, password, debug=False, access_token=None, access_token_expires=None):
         super(EvohomeClient, self).__init__(debug)
@@ -29,43 +30,43 @@ class EvohomeClient(EvohomeBase):
         location = None
         gateway = None
         control_system = None
-        
-        if len(self.locations)==1:
+
+        if len(self.locations) == 1:
             location = self.locations[0]
         else:
             raise Exception("More than one location available")
-            
-        if len(location._gateways)==1:
+
+        if len(location._gateways) == 1:
             gateway = location._gateways[0]
         else:
             raise Exception("More than one gateway available")
-            
-        if len(gateway._control_systems)==1:
+
+        if len(gateway._control_systems) == 1:
             control_system = gateway._control_systems[0]
         else:
             raise Exception("More than one control system available")
-            
+
         return control_system
-        
+
     def _basic_login(self):
         self.access_token = None
         self.access_token_expires = None
 
         url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
         headers = {
-            'Authorization':	'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
+            'Authorization': 'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
             'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
         }
         data = {
-            'Content-Type':	'application/x-www-form-urlencoded; charset=utf-8',
-            'Host':	'rs.alarmnet.com/',
-            'Cache-Control':'no-store no-cache',
-            'Pragma':	'no-cache',
-            'grant_type':	'password',
-            'scope':	'EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account',
-            'Username':	self.username,
-            'Password':	self.password,
-            'Connection':	'Keep-Alive'
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+            'Host': 'rs.alarmnet.com/',
+            'Cache-Control': 'no-store no-cache',
+            'Pragma': 'no-cache',
+            'grant_type': 'password',
+            'scope': 'EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account',
+            'Username': self.username,
+            'Password': self.password,
+            'Connection': 'Keep-Alive'
         }
         r = requests.post(url, data=data, headers=headers)
 
@@ -74,20 +75,20 @@ class EvohomeClient(EvohomeBase):
 
         data = self._convert(r.text)
         self.access_token = data['access_token']
-        self.access_token_expires = datetime.now() + timedelta(seconds = data['expires_in'])
-        
+        self.access_token_expires = datetime.now() + timedelta(seconds=data['expires_in'])
+
     def _login(self):
         self.user_account()
         self.installation()
 
     def headers(self):
         if self.access_token is None or self.access_token_expires is None:
-        # token is invalid
+            # token is invalid
             self._basic_login()
-        elif datetime.now() > self.access_token_expires - timedelta(seconds = 30):
-        # token has expired
+        elif datetime.now() > self.access_token_expires - timedelta(seconds=30):
+            # token has expired
             self._basic_login()
-        
+
         self._headers = {
             'Authorization': 'bearer ' + self.access_token,
             'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
@@ -160,7 +161,7 @@ class EvohomeClient(EvohomeBase):
 
     def temperatures(self):
         return self._get_single_heating_system().temperatures()
-    
+
     def zone_schedules_backup(self, filename):
         return self._get_single_heating_system().zone_schedules_backup(filename)
 

--- a/evohomeclient2/base.py
+++ b/evohomeclient2/base.py
@@ -10,13 +10,15 @@ except ImportError:
     # Python 2
     import httplib as http_client
 
+
 class EvohomeClientInvalidPostData(Exception):
     pass
+
 
 class EvohomeBase(object):
     def __init__(self, debug=False):
         self.reader = codecs.getdecoder("utf-8")
-        
+
         if debug:
             http_client.HTTPConnection.debuglevel = 1
             logging.getLogger(__name__).setLevel(logging.DEBUG)
@@ -27,6 +29,6 @@ class EvohomeBase(object):
             logging.getLogger(__name__).setLevel(logging.INFO)
             requests_log.setLevel(logging.INFO)
             requests_log.propagate = False
-    
+
     def _convert(self, object):
         return json.loads(object)

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -5,6 +5,7 @@ from .zone import Zone
 from .hotwater import HotWater
 from .base import EvohomeBase, EvohomeClientInvalidPostData
 
+
 class ControlSystem(EvohomeBase):
 
     def __init__(self, client, location, gateway, data=None):
@@ -39,9 +40,9 @@ class ControlSystem(EvohomeBase):
         headers['Content-Type'] = 'application/json'
 
         if until is None:
-            data = {"SystemMode":mode,"TimeUntil":None,"Permanent":True}
+            data = {"SystemMode": mode, "TimeUntil": None, "Permanent": True}
         else:
-            data = {"SystemMode":mode,"TimeUntil":"%sT00:00:00Z" % until.strftime('%Y-%m-%d'),"Permanent":False}
+            data = {"SystemMode": mode, "TimeUntil": "%sT00:00:00Z" % until.strftime('%Y-%m-%d'), "Permanent": False}
 
         r = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureControlSystem/%s/mode' % self.systemId, data=json.dumps(data), headers=headers)
 
@@ -74,19 +75,17 @@ class ControlSystem(EvohomeBase):
 
         if self.hotwater:
             yield {'thermostat': 'DOMESTIC_HOT_WATER',
-                    'id': self.hotwater.dhwId,
-                    'name': '',
-                    'temp': self.hotwater.temperatureStatus['temperature'],
-                    'setpoint': ''
-                  }
+                   'id': self.hotwater.dhwId,
+                   'name': '',
+                   'temp': self.hotwater.temperatureStatus['temperature'],
+                   'setpoint': ''}
 
         for zone in self._zones:
             z = {'thermostat': 'EMEA_ZONE',
                  'id': zone.zoneId,
                  'name': zone.name,
                  'temp': None,
-                 'setpoint': zone.setpointStatus['targetHeatTemperature']
-                }
+                 'setpoint': zone.setpointStatus['targetHeatTemperature']}
             if zone.temperatureStatus['isAvailable']:
                 z['temp'] = zone.temperatureStatus['temperature']
             yield z
@@ -95,19 +94,19 @@ class ControlSystem(EvohomeBase):
         print("Backing up zone schedule to: %s" % (filename))
 
         schedules = {}
-        
+
         if self.hotwater:
             print("Retrieving DHW schedule: %s" % self.hotwater.zoneId)
             s = self.hotwater.schedule()
             schedules[self.hotwater.zoneId] = {'name': 'Domestic Hot Water', 'schedule': s}
-        
+
         for z in self._zones:
             zone_id = z.zoneId
             name = z.name
             print("Retrieving zone schedule: %s - %s" % (zone_id, name))
             s = z.schedule()
             schedules[zone_id] = {'name': name, 'schedule': s}
-            
+
         schedule_db = json.dumps(schedules, indent=4)
 
         with open(filename, 'w') as f:
@@ -121,12 +120,12 @@ class ControlSystem(EvohomeBase):
             schedule_db = f.read()
             schedules = json.loads(schedule_db)
             for zone_id, zone_schedule in schedules.items():
-                
+
                 name = zone_schedule['name']
                 zone_info = zone_schedule['schedule']
                 print("Restoring schedule for: %s - %s" % (zone_id, name))
-                
-                if self.hotwater and self.hotwater.zoneId==zone_id:
+
+                if self.hotwater and self.hotwater.zoneId == zone_id:
                     self.hotwater.set_schedule(json.dumps(zone_info))
                 else:
                     self.zones_by_id[zone_id].set_schedule(json.dumps(zone_info))

--- a/evohomeclient2/gateway.py
+++ b/evohomeclient2/gateway.py
@@ -1,7 +1,7 @@
 from .controlsystem import ControlSystem
 
-class Gateway(object):
 
+class Gateway(object):
 
     def __init__(self, client, location, data=None):
         self.client = client

--- a/evohomeclient2/hotwater.py
+++ b/evohomeclient2/hotwater.py
@@ -3,6 +3,7 @@ import json
 
 from .zone import ZoneBase
 
+
 class HotWater(ZoneBase):
 
     def __init__(self, client, data=None):
@@ -25,18 +26,18 @@ class HotWater(ZoneBase):
 
     def set_dhw_on(self, until=None):
         if until is None:
-            data = {"State":"On","Mode":"PermanentOverride","UntilTime":None}
+            data = {"State": "On", "Mode": "PermanentOverride", "UntilTime": None}
         else:
-            data = {"State":"On","Mode":"TemporaryOverride","UntilTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"State": "On", "Mode": "TemporaryOverride", "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_off(self, until=None):
         if until is None:
-            data = {"State":"Off","Mode":"PermanentOverride","UntilTime":None}
+            data = {"State": "Off", "Mode": "PermanentOverride", "UntilTime": None}
         else:
-            data = {"State":"Off","Mode":"TemporaryOverride","UntilTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"State": "Off", "Mode": "TemporaryOverride", "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_auto(self):
-        data =  {"State":"","Mode":"FollowSchedule","UntilTime":None}
+        data = {"State": "", "Mode": "FollowSchedule", "UntilTime": None}
         self._set_dhw(data)

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -2,6 +2,7 @@ from .gateway import Gateway
 from .base import EvohomeBase
 import requests
 
+
 class Location(EvohomeBase):
 
     def __init__(self, client, data=None):

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -2,6 +2,7 @@ import json
 import requests
 from .base import EvohomeBase, EvohomeClientInvalidPostData
 
+
 class ZoneBase(EvohomeBase):
     def __init__(self):
         super(ZoneBase, self).__init__()
@@ -23,13 +24,13 @@ class ZoneBase(EvohomeBase):
         j = r.text
         for f, t in mapping:
             j = j.replace(f, t)
-            
+
         d = self._convert(j)
         # change the day name string to a number offset (0 = Monday)
         for day_of_week, schedule in enumerate(d['DailySchedules']):
             schedule['DayOfWeek'] = day_of_week
         return d
-        
+
     def set_schedule(self, zone_info):
         # must only POST json, otherwise server API handler raises exceptions
 
@@ -47,6 +48,7 @@ class ZoneBase(EvohomeBase):
 
         return self._convert(r.text)
 
+
 class Zone(ZoneBase):
 
     def __init__(self, client, data=None):
@@ -58,9 +60,9 @@ class Zone(ZoneBase):
 
     def set_temperature(self, temperature, until=None):
         if until is None:
-            data = {"HeatSetpointValue":temperature,"SetpointMode":"PermanentOverride","TimeUntil":None}
+            data = {"HeatSetpointValue": temperature, "SetpointMode": "PermanentOverride", "TimeUntil": None}
         else:
-            data = {"HeatSetpointValue":temperature,"SetpointMode":"TemporaryOverride","TimeUntil":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"HeatSetpointValue": temperature, "SetpointMode": "TemporaryOverride", "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_heat_setpoint(data)
 
     def _set_heat_setpoint(self, data):
@@ -73,6 +75,5 @@ class Zone(ZoneBase):
             r.raise_for_status()
 
     def cancel_temp_override(self, *args, **kwargs):
-        data = {"HeatSetpointValue":0.0,"SetpointMode":"FollowSchedule","TimeUntil":None}
+        data = {"HeatSetpointValue": 0.0, "SetpointMode": "FollowSchedule", "TimeUntil": None}
         self._set_heat_setpoint(data)
-

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,18 @@
 from setuptools import setup
 
 setup(
-	name = 'evohomeclient',
-	version = '0.2.8',
-	description = 'Python client for connecting to the Evohome webservice',
-	url = 'https://github.com/watchforstock/evohome-client/',
-	download_url = 'https://github.com/watchforstock/evohome-client/tarball/0.2.8',
-	author = 'Andrew Stock',
-	author_email = 'evohome@andrew-stock.com',
-	license = 'Apache 2',
-	classifiers = [
-		'Development Status :: 3 - Alpha',
-	],
-	keywords = ['evohome'],
-	packages = ['evohomeclient', 'evohomeclient2'],
-	install_requires = ['requests']
+    name='evohomeclient',
+    version='0.2.8',
+    description='Python client for connecting to the Evohome webservice',
+    url='https://github.com/watchforstock/evohome-client/',
+    download_url='https://github.com/watchforstock/evohome-client/tarball/0.2.8',
+    author='Andrew Stock',
+    author_email='evohome@andrew-stock.com',
+    license='Apache 2',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+    ],
+    keywords=['evohome'],
+    packages=['evohomeclient', 'evohomeclient2'],
+    install_requires=['requests']
 )


### PR DESCRIPTION
This PR only changes white space as reported by **flake8**.

I have run it in my normal test-bed (which polls v1 and v2 APIs), and it is running OK.  

```bash
(hass) dbonnes@vm-builder:~/evohome-client$ flake8 --ignore=E501 evohomeclient/*
evohomeclient/__init__.py:117:66: F821 undefined name 'basestring'
```
and
```bash
(hass) dbonnes@vm-builder:~/evohome-client$ flake8 --ignore=E501 evohomeclient2/*
evohomeclient2/controlsystem.py:6:1: F401 '.base.EvohomeClientInvalidPostData' imported but unused
evohomeclient2/controlsystem.py:74:9: F841 local variable 'status' is assigned to but never used
evohomeclient2/__init__.py:3:1: F401 'json' imported but unused
evohomeclient2/__init__.py:4:1: F401 'codecs' imported but unused
evohomeclient2/zone.py:38:13: F841 local variable 't1' is assigned to but never used
evohomeclient2/zone.py:39:9: E722 do not use bare except'
```

I have not run **pylint**, yet!