### PR TITLE
De-lint step two

### DIFF
--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -114,7 +114,7 @@ class EvohomeClient:
         return device['thermostat']['allowedModes']
 
     def _get_device(self, zone):
-        if isinstance(zone, str) or (is_py2 and isinstance(zone, basestring)):
+        if isinstance(zone, str) or (is_py2 and isinstance(zone, basestring)):   # noqa: F821, E501
             device = self.named_devices[zone]
         else:
             device = self.devices[zone]

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -74,6 +74,7 @@ class EvohomeClient(EvohomeBase):
             r.raise_for_status()
 
         data = self._convert(r.text)
+
         self.refresh_token = data['refresh_token']
         self.access_token = data['access_token']
         self.access_token_expires = datetime.now() + timedelta(seconds=data['expires_in'])

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import print_function
 import requests
-import json
-import codecs
+# import json
+# import codecs
 from datetime import datetime, timedelta
 from .location import Location
 from .base import EvohomeBase
@@ -74,6 +74,7 @@ class EvohomeClient(EvohomeBase):
             r.raise_for_status()
 
         data = self._convert(r.text)
+        self.refresh_token = data['refresh_token']
         self.access_token = data['access_token']
         self.access_token_expires = datetime.now() + timedelta(seconds=data['expires_in'])
 

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 import requests
-# import json
-# import codecs
 from datetime import datetime, timedelta
 from .location import Location
 from .base import EvohomeBase

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -3,7 +3,7 @@ import requests
 
 from .zone import Zone
 from .hotwater import HotWater
-from .base import EvohomeBase  # , EvohomeClientInvalidPostData
+from .base import EvohomeBase
 
 
 class ControlSystem(EvohomeBase):
@@ -71,8 +71,6 @@ class ControlSystem(EvohomeBase):
         self._set_status("HeatingOff", until)
 
     def temperatures(self):
-        # status = self.location.status()
-
         if self.hotwater:
             yield {'thermostat': 'DOMESTIC_HOT_WATER',
                    'id': self.hotwater.dhwId,

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -3,7 +3,7 @@ import requests
 
 from .zone import Zone
 from .hotwater import HotWater
-from .base import EvohomeBase, EvohomeClientInvalidPostData
+from .base import EvohomeBase  # , EvohomeClientInvalidPostData
 
 
 class ControlSystem(EvohomeBase):
@@ -71,7 +71,7 @@ class ControlSystem(EvohomeBase):
         self._set_status("HeatingOff", until)
 
     def temperatures(self):
-        status = self.location.status()
+        # status = self.location.status()
 
         if self.hotwater:
             yield {'thermostat': 'DOMESTIC_HOT_WATER',

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -37,7 +37,7 @@ class ZoneBase(EvohomeBase):
         try:
             json.loads(zone_info)
         except ValueError as error:
-            raise EvohomeClientInvalidPostData('zone_info must be valid JSON')
+            raise EvohomeClientInvalidPostData('zone_info must be valid JSON: ', error)
 
         headers = dict(self.client.headers())
         headers['Content-Type'] = 'application/json'

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -35,9 +35,9 @@ class ZoneBase(EvohomeBase):
         # must only POST json, otherwise server API handler raises exceptions
 
         try:
-            t1 = json.loads(zone_info)
-        except:
-            raise EvohomeClientInvalidPostData('zone_info must be JSON')
+            json.loads(zone_info)
+        except ValueError as error:
+            raise EvohomeClientInvalidPostData('zone_info must be valid JSON')
 
         headers = dict(self.client.headers())
         headers['Content-Type'] = 'application/json'


### PR DESCRIPTION
There are now no errors from `flake8 --ignore=E501 evohomeclient2/*`.

I have also added `self.refresh_token = data['refresh_token']`, and made a tweak to the `EvohomeClientInvalidPostData` exception.

Having the refresh token will aloow experimentation with **curl** to develop an alternative to re-authenticating when the `access_token` expires.