### PR TITLE
Big refactor of evohome-client v1

### DIFF
--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -59,17 +59,20 @@ class EvohomeClient:
     def _populate_full_data(self, force_refresh=False):
         if self.full_data is None or force_refresh:
             self._populate_user_info()
+
             try:
                 user_id = self.user_data['userInfo']['userID']
                 session_id = self.user_data['sessionId']
             except Exception as error:
                 raise Exception('Invalid user_data: %s' % repr(self.user_data)) from error
 
-            url = 'https://tccna.honeywell.com/WebAPI/api/locations?userId=%s&allData=True' % user_id
-
+            url = ("https://tccna.honeywell.com/WebAPI/api/locations"
+                   "?userId=%s&allData=True" % user_id)
             self.headers['sessionId'] = session_id
 
-            response = requests.get(url, data=json.dumps(self.postdata), headers=self.headers)
+            response = requests.get(url,
+                                    data=json.dumps(self.postdata),
+                                    headers=self.headers)
 
             self.full_data = self._convert(response.content)[0]
 
@@ -82,24 +85,26 @@ class EvohomeClient:
                 for device in self.full_data['devices']:
                     self.devices[device['deviceID']] = device
                     self.named_devices[device['name']] = device
+
             except Exception as error:
                 raise Exception('Invalid full_data: %s' % repr(self.full_data)) from error
 
     def _populate_gateway_info(self):
         self._populate_full_data()
         if self.gateway_data is None:
-            url = 'https://tccna.honeywell.com/WebAPI/api/gateways?locationId=%s&allData=False' % self.location_id
+            url = ("https://tccna.honeywell.com/WebAPI/api/gateways"
+                   "?locationId=%s&allData=False" % self.location_id)
+
             response = requests.get(url, headers=self.headers)
 
             self.gateway_data = self._convert(response.content)[0]
 
     def _populate_user_info(self):
         if self.user_data is None:
-            url = 'https://tccna.honeywell.com/WebAPI/api/Session'
+            url = "https://tccna.honeywell.com/WebAPI/api/Session"
             self.postdata = {'Username': self.username,
                              'Password': self.password,
                              'ApplicationId': '91db1612-73fd-4500-91b2-e63b069b185c'}
-
             self.headers = {'content-type': 'application/json'}
 
             response = requests.post(url,
@@ -128,7 +133,7 @@ class EvohomeClient:
         return device['thermostat']['allowedModes']
 
     def _get_device(self, zone):
-        if isinstance(zone, str) or (IS_PY2 and isinstance(zone, basestring)):   # noqa: F821, E501; pylint: disable=undefined-variable
+        if isinstance(zone, str) or (IS_PY2 and isinstance(zone, basestring)):   # noqa: F821; pylint: disable=undefined-variable
             device = self.named_devices[zone]
         else:
             device = self.devices[zone]
@@ -136,7 +141,9 @@ class EvohomeClient:
 
     def _get_task_status(self, task_id):
         self._populate_full_data()
-        url = 'https://tccna.honeywell.com/WebAPI/api/commTasks?commTaskId=%s' % task_id
+        url = ("https://tccna.honeywell.com/WebAPI/api/commTasks"
+               "?commTaskId=%s" % task_id)
+
         response = requests.get(url, headers=self.headers)
 
         return self._convert(response.content)['state']
@@ -152,11 +159,14 @@ class EvohomeClient:
 
     def _set_status(self, status, until=None):
         self._populate_full_data()
-        url = 'https://tccna.honeywell.com/WebAPI/api/evoTouchSystems?locationId=%s' % self.location_id
+        url = ("https://tccna.honeywell.com/WebAPI/api/evoTouchSystems"
+               "?locationId=%s" % self.location_id)
+
         if until is None:
             data = {"QuickAction": status, "QuickActionNextTime": None}
         else:
             data = {"QuickAction": status, "QuickActionNextTime": "%sT00:00:00Z" % until.strftime('%Y-%m-%d')}
+
         response = requests.put(url,
                                 data=json.dumps(data),
                                 headers=self.headers)
@@ -193,7 +203,9 @@ class EvohomeClient:
 
         device_id = self._get_device_id(zone)
 
-        url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues/heatSetpoint' % device_id
+        url = ("https://tccna.honeywell.com/WebAPI/api/devices"
+               "/%s/thermostat/changeableValues/heatSetpoint" % device_id)
+
         response = requests.put(url, json.dumps(data), headers=self.headers)
 
         task_id = self._get_task_id(response)
@@ -221,9 +233,17 @@ class EvohomeClient:
                 return device['deviceID']
         return None
 
-    def _set_dhw(self, data):
+    def _set_dhw(self, status="Scheduled", mode=None, next_time=None):
+        data = {"Status": status,
+                "Mode": mode,
+                "NextTime": next_time,
+                "SpecialModes": None,
+                "HeatSetpoint": None,
+                "CoolSetpoint": None}
+
         self._populate_full_data()
-        url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues' % self._get_dhw_zone()
+        url = ("https://tccna.honeywell.com/WebAPI/api/devices"
+               "/%s/thermostat/changeableValues" % self._get_dhw_zone())
 
         response = requests.put(url,
                                 data=json.dumps(data),
@@ -235,49 +255,14 @@ class EvohomeClient:
             time.sleep(1)
 
     def set_dhw_on(self, until=None):
-        if until is None:
-            data = {"Mode": "DHWOn",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": None}
+        timex = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
 
-        else:
-            data = {"Mode": "DHWOn",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
-
-        self._set_dhw(data)
+        self._set_dhw(status="Hold", mode="DHWOn", next_time=timex)
 
     def set_dhw_off(self, until=None):
-        if until is None:
-            data = {"Mode": "DHWOff",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": None}
+        timex = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
 
-        else:
-            data = {"Mode": "DHWOff",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
-
-        self._set_dhw(data)
+        self._set_dhw(status="Hold", mode="DHWOff", next_time=timex)
 
     def set_dhw_auto(self):
-        data = {"Mode": None,
-                "SpecialModes": None,
-                "HeatSetpoint": None,
-                "CoolSetpoint": None,
-                "Status": "Scheduled",
-                "NextTime": None}
-
-        self._set_dhw(data)
+        self._set_dhw(status="Scheduled")

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -255,14 +255,14 @@ class EvohomeClient:
             time.sleep(1)
 
     def set_dhw_on(self, until=None):
-        timex = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
+        time_until = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
 
-        self._set_dhw(status="Hold", mode="DHWOn", next_time=timex)
+        self._set_dhw(status="Hold", mode="DHWOn", next_time=time_until)
 
     def set_dhw_off(self, until=None):
-        timex = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
+        time_until = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
 
-        self._set_dhw(status="Hold", mode="DHWOff", next_time=timex)
+        self._set_dhw(status="Hold", mode="DHWOff", next_time=time_until)
 
     def set_dhw_auto(self):
         self._set_dhw(status="Scheduled")

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -234,6 +234,8 @@ class EvohomeClient:
         return None
 
     def _set_dhw(self, status="Scheduled", mode=None, next_time=None):
+        """Set DHW to On, Off or Auto, either indefinitely, or until a
+        specified time."""
         data = {"Status": status,
                 "Mode": mode,
                 "NextTime": next_time,
@@ -255,14 +257,28 @@ class EvohomeClient:
             time.sleep(1)
 
     def set_dhw_on(self, until=None):
+        """Set DHW to on, either indefinitely, or until a specified time.
+
+        When On, the DHW controller will work to keep its target temperature
+        at/above its target temperature.  After the specified time, it will
+        revert to its scheduled behaviour.
+        """
+
         time_until = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
 
         self._set_dhw(status="Hold", mode="DHWOn", next_time=time_until)
 
     def set_dhw_off(self, until=None):
+        """Set DHW to on, either indefinitely, or until a specified time.
+
+        When Off, the DHW controller will ignore its target temperature. After
+        the specified time, it will revert to its scheduled behaviour.
+        """
+
         time_until = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
 
         self._set_dhw(status="Hold", mode="DHWOff", next_time=time_until)
 
     def set_dhw_auto(self):
+        """Set DHW to On or Off, according to its schedule."""
         self._set_dhw(status="Scheduled")


### PR DESCRIPTION
This is a refactored version of **evohome-client** v1.  It doesn't offer any more functionality but, usefully, it has no lint, except for `line-too-long` and `missing-docstring`.

```bash
(hass) dbonnes@vm-builder:~/evohome-client$ flake8 --ignore=E501 evohomeclient/__init__.py
(hass) dbonnes@vm-builder:~/evohome-client$ pylint --disable=C0301,C0111 evohomeclient/__init__.py

--------------------------------------------------------------------
Your code has been rated at 10.00/10 (previous run: 10.00/10, +0.00)
```