### PR TITLE
Better handling of exceptions

### DIFF
--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -112,7 +112,9 @@ class EvohomeClient:
                 response.raise_for_status()
             if response.status_code != requests.codes.ok:                        # pylint: disable=no-member
                 if 'code' in response.text:  # don't use response.json()!
-                    raise requests.HTTPError(response.text)
+                    message = ("HTTP Status = %s, Response = %s",
+                               response.status_code, response.text)
+                    raise requests.HTTPError(message)
 
             self.user_data = self._convert(response.content)
 

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -112,10 +112,9 @@ class EvohomeClient:
                 response.raise_for_status()
             if response.status_code != requests.codes.ok:                        # pylint: disable=no-member
                 if 'code' in response.text:  # don't use response.json()!
-                    raise requests.HTTPError("HTTP Status = " +
-                                             response.status_code +
-                                             ", Response = " +
-                                             response.text)
+                    message = ("HTTP Status = " + str(response.status_code) +
+                               ", Response = " + response.text)
+                    raise requests.HTTPError(message)
 
             self.user_data = self._convert(response.content)
 

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -112,9 +112,10 @@ class EvohomeClient:
                 response.raise_for_status()
             if response.status_code != requests.codes.ok:                        # pylint: disable=no-member
                 if 'code' in response.text:  # don't use response.json()!
-                    message = ("HTTP Status = %s, Response = %s",
-                               response.status_code, response.text)
-                    raise requests.HTTPError(message)
+                    raise requests.HTTPError("HTTP Status = " +
+                                             response.status_code +
+                                             ", Response = " +
+                                             response.text)
 
             self.user_data = self._convert(response.content)
 

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -107,6 +107,9 @@ class EvohomeClient:
                                      data=json.dumps(self.postdata),
                                      headers=self.headers)
 
+            # catch 429/too_many_requests first, for consistency
+            if response.status_code == requests.codes.too_many_requests:         # pylint: disable=no-member
+                response.raise_for_status()
             if response.status_code != requests.codes.ok:                        # pylint: disable=no-member
                 if 'code' in response.text:  # don't use response.json()!
                     raise requests.HTTPError(response.text)


### PR DESCRIPTION
On invocation, the first RESTful API call is in `_populate_user_info()`. Notably, it can return an error, for example (see #53):
```JSON
[{ "code": "LatestEulaNotAccepted", "message": "Latest Eula is not accepted." }]
```
In addition, *any* of the API calls could return (via a HTML_STATUS_429):
```json
[{  "code": "TooManyRequests", "message": "Request count limitation exceeded..." }]
```

This PR adds `response.raise_for_status()` after every **requests** call, but the handling is different for the first as we wont get the (potentially useful) error message otherwise.

It removes the two `try` / `except` blocks, which were unsatisfactory (but did provide a useful message in a round-about way):
```python
except Exception as error:		
    raise Exception('Invalid user_data: %s' % repr(self.user_data)) from error
```
In this case, a (say) 429 had not been caught much earlier in the code and (for example) `self.user_data` contains the corresponding error message (`TooManyRequests`) rather than the expected JSON.

Subsequently, this line:
```python
user_id = self.user_data['userInfo']['userID']
```
causes an `TypeError` since:
```python
self.user_data == [{ "code": "LatestEulaNotAccepted", "message": "Latest Eula is not accepted." }]
```

This code addresses the issues raised in #53, but replaces the corresponding fix, #54, with potentially better code.