### PR TITLE
Improve debug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,49 @@
+version: 2 # use CircleCI 2.0
+jobs: # A basic unit of work in a run
+  build: # runs not using Workflows must have a `build` job as entry point 
+    # directory where steps are run
+    working_directory: ~/circleci-evohomeclient
+    docker: # run the steps with Docker
+      # CircleCI Python images available at: https://hub.docker.com/r/circleci/python/
+      - image: circleci/python:3.6.4
+    steps: # steps that comprise the `build` job
+      - checkout # check out source code to working directory
+      - run: sudo chown -R circleci:circleci /usr/local/bin
+      - run: sudo chown -R circleci:circleci /usr/local/lib/python3.6/site-packages
+      - run:
+          command: |
+            sudo pip install nose requests_mock coverage pylint
+      - run:
+          command: |
+            mkdir test-results
+            pip install requests
+  test:
+    docker:
+      - image: circleci/python:3.6.4
+    steps:
+      - checkout
+      - run:
+          command: |
+            sudo pip install nose requests_mock coverage pylint
+      - run:
+          command: |
+            mkdir test-results
+            pip install requests
+      - run:
+          name: Test
+          command: |
+            pylint --disable=C0301 evohomeclient
+            nosetests --xunit-file=test-results/junit.xml
+      - store_test_results: # Upload test results for display in Test Summary: https://circleci.com/docs/2.0/collect-test-data/
+          path: test-results
+      - store_artifacts: # Upload test summary for display in Artifacts: https://circleci.com/docs/2.0/artifacts/
+          path: htmlcov
+          destination: coverate
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build          

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ test2.py
 /backup.json
 .idea
 /.vscode
+.gitignore.swp
+test-reports/junit.xml

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,12 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+requests = "*"
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,57 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "bb57e0d7853b45999e47c163c46b95bc2fde31c527d8d7b5b5539dc979444a6d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "certifi": {
+            "hashes": [
+                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
+                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+            ],
+            "version": "==2018.11.29"
+        },
+        "chardet": {
+            "hashes": [
+                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
+                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
+            ],
+            "version": "==3.0.4"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:c357b3f628cf53ae2c4c05627ecc484553142ca23264e593d327bcde5e9c3407",
+                "sha256:ea8b7f6188e6fa117537c3df7da9fc686d485087abf6ac197f9c46432f7e4a3c"
+            ],
+            "version": "==2.8"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:502a824f31acdacb3a35b6690b5fbf0bc41d63a24a45c4004352b0242707598e",
+                "sha256:7bf2a778576d825600030a110f3c0e3e8edc51dfaafe1c146e39a2027784957b"
+            ],
+            "index": "pypi",
+            "version": "==2.21.0"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:61bf29cada3fc2fbefad4fdf059ea4bd1b4a86d2b6d15e1c7c0b582b9752fe39",
+                "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
+            ],
+            "version": "==1.24.1"
+        }
+    },
+    "develop": {}
+}

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -225,7 +225,9 @@ class EvohomeClient:
         self._populate_full_data()
         url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues' % self._get_dhw_zone()
 
-        response = requests.put(url, data=json.dumps(data), headers=self.headers)
+        response = requests.put(url,
+                                data=json.dumps(data),
+                                headers=self.headers)
 
         task_id = self._get_task_id(response)
 

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -4,6 +4,15 @@ import json
 import time
 import codecs
 import sys
+import logging
+logging.basicConfig()
+requests_log = logging.getLogger("requests.packages.urllib3")
+
+try:
+    import http.client as http_client
+except ImportError:
+    # Python 2
+    import httplib as http_client
 
 
 # stole this from requests libary. To determine whether we are dealing
@@ -16,13 +25,24 @@ is_py2=(_ver[0]==2)
 is_py3=(_ver[0]==3)
 
 class EvohomeClient:
-    def __init__(self, username, password):
+    def __init__(self, username, password, debug = False, user_data = None):
         self.username = username
         self.password = password
-        self.user_data = None
+        self.user_data = user_data
         self.full_data = None
         self.gateway_data = None
         self.reader = codecs.getdecoder("utf-8")
+
+        if debug:
+            http_client.HTTPConnection.debuglevel = 1
+            logging.getLogger(__name__).setLevel(logging.DEBUG)
+            requests_log.setLevel(logging.DEBUG)
+            requests_log.propagate = True
+        else:
+            http_client.HTTPConnection.debuglevel = 0
+            logging.getLogger(__name__).setLevel(logging.INFO)
+            requests_log.setLevel(logging.INFO)
+            requests_log.propagate = False
     
     def _convert(self, object):
         return json.loads(self.reader(object)[0])

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -42,8 +42,8 @@ class EvohomeClient:
         self.user_data = user_data
         self.hostname = hostname
 
-        self.full_data = {}
-        self.gateway_data = {}
+        self.full_data = None
+        self.gateway_data = None
         self.reader = codecs.getdecoder("utf-8")
 
         self.location_id = ""

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -32,6 +32,7 @@ class EvohomeClient:
         self.username = username
         self.password = password
         self.user_data = user_data
+
         self.full_data = None
         self.gateway_data = None
         self.reader = codecs.getdecoder("utf-8")
@@ -60,11 +61,8 @@ class EvohomeClient:
         if self.full_data is None or force_refresh:
             self._populate_user_info()
 
-            try:
-                user_id = self.user_data['userInfo']['userID']
-                session_id = self.user_data['sessionId']
-            except Exception as error:
-                raise Exception('Invalid user_data: %s' % repr(self.user_data)) from error
+            user_id = self.user_data['userInfo']['userID']
+            session_id = self.user_data['sessionId']
 
             url = ("https://tccna.honeywell.com/WebAPI/api/locations"
                    "?userId=%s&allData=True" % user_id)
@@ -73,21 +71,18 @@ class EvohomeClient:
             response = requests.get(url,
                                     data=json.dumps(self.postdata),
                                     headers=self.headers)
+            response.raise_for_status()
 
             self.full_data = self._convert(response.content)[0]
 
-            try:
-                self.location_id = self.full_data['locationID']
+            self.location_id = self.full_data['locationID']
 
-                self.devices = {}
-                self.named_devices = {}
+            self.devices = {}
+            self.named_devices = {}
 
-                for device in self.full_data['devices']:
-                    self.devices[device['deviceID']] = device
-                    self.named_devices[device['name']] = device
-
-            except Exception as error:
-                raise Exception('Invalid full_data: %s' % repr(self.full_data)) from error
+            for device in self.full_data['devices']:
+                self.devices[device['deviceID']] = device
+                self.named_devices[device['name']] = device
 
     def _populate_gateway_info(self):
         self._populate_full_data()
@@ -96,6 +91,7 @@ class EvohomeClient:
                    "?locationId=%s&allData=False" % self.location_id)
 
             response = requests.get(url, headers=self.headers)
+            response.raise_for_status()
 
             self.gateway_data = self._convert(response.content)[0]
 
@@ -110,6 +106,15 @@ class EvohomeClient:
             response = requests.post(url,
                                      data=json.dumps(self.postdata),
                                      headers=self.headers)
+
+            # catch 429/too_many_requests first, for consistency
+            if response.status_code == requests.codes.too_many_requests:         # pylint: disable=no-member
+                response.raise_for_status()
+            if response.status_code != requests.codes.ok:                        # pylint: disable=no-member
+                if 'code' in response.text:  # don't use response.json()!
+                    message = ("HTTP Status = " + str(response.status_code) +
+                               ", Response = " + response.text)
+                    raise requests.HTTPError(message)
 
             self.user_data = self._convert(response.content)
 
@@ -145,6 +150,7 @@ class EvohomeClient:
                "?commTaskId=%s" % task_id)
 
         response = requests.get(url, headers=self.headers)
+        response.raise_for_status()
 
         return self._convert(response.content)['state']
 
@@ -170,6 +176,7 @@ class EvohomeClient:
         response = requests.put(url,
                                 data=json.dumps(data),
                                 headers=self.headers)
+        response.raise_for_status()
 
         task_id = self._get_task_id(response)
 
@@ -207,6 +214,7 @@ class EvohomeClient:
                "/%s/thermostat/changeableValues/heatSetpoint" % device_id)
 
         response = requests.put(url, json.dumps(data), headers=self.headers)
+        response.raise_for_status()
 
         task_id = self._get_task_id(response)
 
@@ -250,6 +258,7 @@ class EvohomeClient:
         response = requests.put(url,
                                 data=json.dumps(data),
                                 headers=self.headers)
+        response.raise_for_status()
 
         task_id = self._get_task_id(response)
 

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -116,7 +116,7 @@ class EvohomeClient:
                                      data=json.dumps(self.postdata),
                                      headers=self.headers)
 
-            # catch 429/too_many_requests first, for consistency
+            # catch 429/too_many_requests first, for a consistent experience
             if response.status_code == requests.codes.too_many_requests:         # pylint: disable=no-member
                 response.raise_for_status()
             if response.status_code != requests.codes.ok:                        # pylint: disable=no-member
@@ -124,6 +124,7 @@ class EvohomeClient:
                     message = ("HTTP Status = " + str(response.status_code) +
                                ", Response = " + response.text)
                     raise requests.HTTPError(message)
+                response.raise_for_status()
 
             self.user_data = self._convert(response.content)
 

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -42,15 +42,15 @@ class EvohomeClient:
         self.user_data = user_data
         self.hostname = hostname
 
-        self.full_data = None
-        self.gateway_data = None
+        self.full_data = {}
+        self.gateway_data = {}
         self.reader = codecs.getdecoder("utf-8")
 
-        self.location_id = None
-        self.devices = None
-        self.named_devices = None
-        self.postdata = None
-        self.headers = None
+        self.location_id = ""
+        self.devices = {}
+        self.named_devices = {}
+        self.postdata = {}
+        self.headers = {}
 
         if debug is True:
             http_client.HTTPConnection.debuglevel = 1

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -59,17 +59,20 @@ class EvohomeClient:
     def _populate_full_data(self, force_refresh=False):
         if self.full_data is None or force_refresh:
             self._populate_user_info()
+
             try:
                 user_id = self.user_data['userInfo']['userID']
                 session_id = self.user_data['sessionId']
             except Exception as error:
                 raise Exception('Invalid user_data: %s' % repr(self.user_data)) from error
 
-            url = 'https://tccna.honeywell.com/WebAPI/api/locations?userId=%s&allData=True' % user_id
-
+            url = ("https://tccna.honeywell.com/WebAPI/api/locations"
+                   "?userId=%s&allData=True" % user_id)
             self.headers['sessionId'] = session_id
 
-            response = requests.get(url, data=json.dumps(self.postdata), headers=self.headers)
+            response = requests.get(url,
+                                    data=json.dumps(self.postdata),
+                                    headers=self.headers)
 
             self.full_data = self._convert(response.content)[0]
 
@@ -82,24 +85,26 @@ class EvohomeClient:
                 for device in self.full_data['devices']:
                     self.devices[device['deviceID']] = device
                     self.named_devices[device['name']] = device
+
             except Exception as error:
                 raise Exception('Invalid full_data: %s' % repr(self.full_data)) from error
 
     def _populate_gateway_info(self):
         self._populate_full_data()
         if self.gateway_data is None:
-            url = 'https://tccna.honeywell.com/WebAPI/api/gateways?locationId=%s&allData=False' % self.location_id
+            url = ("https://tccna.honeywell.com/WebAPI/api/gateways"
+                   "?locationId=%s&allData=False" % self.location_id)
+
             response = requests.get(url, headers=self.headers)
 
             self.gateway_data = self._convert(response.content)[0]
 
     def _populate_user_info(self):
         if self.user_data is None:
-            url = 'https://tccna.honeywell.com/WebAPI/api/Session'
+            url = "https://tccna.honeywell.com/WebAPI/api/Session"
             self.postdata = {'Username': self.username,
                              'Password': self.password,
                              'ApplicationId': '91db1612-73fd-4500-91b2-e63b069b185c'}
-
             self.headers = {'content-type': 'application/json'}
 
             response = requests.post(url,
@@ -128,7 +133,7 @@ class EvohomeClient:
         return device['thermostat']['allowedModes']
 
     def _get_device(self, zone):
-        if isinstance(zone, str) or (IS_PY2 and isinstance(zone, basestring)):   # noqa: F821, E501; pylint: disable=undefined-variable
+        if isinstance(zone, str) or (IS_PY2 and isinstance(zone, basestring)):   # noqa: F821; pylint: disable=undefined-variable
             device = self.named_devices[zone]
         else:
             device = self.devices[zone]
@@ -136,7 +141,9 @@ class EvohomeClient:
 
     def _get_task_status(self, task_id):
         self._populate_full_data()
-        url = 'https://tccna.honeywell.com/WebAPI/api/commTasks?commTaskId=%s' % task_id
+        url = ("https://tccna.honeywell.com/WebAPI/api/commTasks"
+               "?commTaskId=%s" % task_id)
+
         response = requests.get(url, headers=self.headers)
 
         return self._convert(response.content)['state']
@@ -152,11 +159,14 @@ class EvohomeClient:
 
     def _set_status(self, status, until=None):
         self._populate_full_data()
-        url = 'https://tccna.honeywell.com/WebAPI/api/evoTouchSystems?locationId=%s' % self.location_id
+        url = ("https://tccna.honeywell.com/WebAPI/api/evoTouchSystems"
+               "?locationId=%s" % self.location_id)
+
         if until is None:
             data = {"QuickAction": status, "QuickActionNextTime": None}
         else:
             data = {"QuickAction": status, "QuickActionNextTime": "%sT00:00:00Z" % until.strftime('%Y-%m-%d')}
+
         response = requests.put(url,
                                 data=json.dumps(data),
                                 headers=self.headers)
@@ -193,7 +203,9 @@ class EvohomeClient:
 
         device_id = self._get_device_id(zone)
 
-        url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues/heatSetpoint' % device_id
+        url = ("https://tccna.honeywell.com/WebAPI/api/devices"
+               "/%s/thermostat/changeableValues/heatSetpoint" % device_id)
+
         response = requests.put(url, json.dumps(data), headers=self.headers)
 
         task_id = self._get_task_id(response)
@@ -221,9 +233,19 @@ class EvohomeClient:
                 return device['deviceID']
         return None
 
-    def _set_dhw(self, data):
+    def _set_dhw(self, status="Scheduled", mode=None, next_time=None):
+        """Set DHW to On, Off or Auto, either indefinitely, or until a
+        specified time."""
+        data = {"Status": status,
+                "Mode": mode,
+                "NextTime": next_time,
+                "SpecialModes": None,
+                "HeatSetpoint": None,
+                "CoolSetpoint": None}
+
         self._populate_full_data()
-        url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues' % self._get_dhw_zone()
+        url = ("https://tccna.honeywell.com/WebAPI/api/devices"
+               "/%s/thermostat/changeableValues" % self._get_dhw_zone())
 
         response = requests.put(url,
                                 data=json.dumps(data),
@@ -235,49 +257,28 @@ class EvohomeClient:
             time.sleep(1)
 
     def set_dhw_on(self, until=None):
-        if until is None:
-            data = {"Mode": "DHWOn",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": None}
+        """Set DHW to on, either indefinitely, or until a specified time.
 
-        else:
-            data = {"Mode": "DHWOn",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+        When On, the DHW controller will work to keep its target temperature
+        at/above its target temperature.  After the specified time, it will
+        revert to its scheduled behaviour.
+        """
 
-        self._set_dhw(data)
+        time_until = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        self._set_dhw(status="Hold", mode="DHWOn", next_time=time_until)
 
     def set_dhw_off(self, until=None):
-        if until is None:
-            data = {"Mode": "DHWOff",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": None}
+        """Set DHW to on, either indefinitely, or until a specified time.
 
-        else:
-            data = {"Mode": "DHWOff",
-                    "SpecialModes": None,
-                    "HeatSetpoint": None,
-                    "CoolSetpoint": None,
-                    "Status": "Hold",
-                    "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+        When Off, the DHW controller will ignore its target temperature. After
+        the specified time, it will revert to its scheduled behaviour.
+        """
 
-        self._set_dhw(data)
+        time_until = None if until is None else until.strftime('%Y-%m-%dT%H:%M:%SZ')
+
+        self._set_dhw(status="Hold", mode="DHWOff", next_time=time_until)
 
     def set_dhw_auto(self):
-        data = {"Mode": None,
-                "SpecialModes": None,
-                "HeatSetpoint": None,
-                "CoolSetpoint": None,
-                "Status": "Scheduled",
-                "NextTime": None}
-
-        self._set_dhw(data)
+        """Set DHW to On or Off, according to its schedule."""
+        self._set_dhw(status="Scheduled")

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -20,12 +20,13 @@ except ImportError:
 _ver = sys.version_info
 
 #: Python 2.x?
-is_py2=(_ver[0]==2)
+is_py2 = (_ver[0] == 2)
 #: Python 3.x?
-is_py3=(_ver[0]==3)
+is_py3 = (_ver[0] == 3)
+
 
 class EvohomeClient:
-    def __init__(self, username, password, debug = False, user_data = None):
+    def __init__(self, username, password, debug=False, user_data=None):
         self.username = username
         self.password = password
         self.user_data = user_data
@@ -43,7 +44,7 @@ class EvohomeClient:
             logging.getLogger(__name__).setLevel(logging.INFO)
             requests_log.setLevel(logging.INFO)
             requests_log.propagate = False
-    
+
     def _convert(self, object):
         return json.loads(self.reader(object)[0])
 
@@ -60,16 +61,16 @@ class EvohomeClient:
 
             self.headers['sessionId'] = sessionId
 
-            response = requests.get(url,data=json.dumps(self.postdata),headers=self.headers)
+            response = requests.get(url, data=json.dumps(self.postdata), headers=self.headers)
 
             self.full_data = self._convert(response.content)[0]
-            
+
             try:
                 self.location_id = self.full_data['locationID']
-            
+
                 self.devices = {}
                 self.named_devices = {}
-            
+
                 for device in self.full_data['devices']:
                     self.devices[device['deviceID']] = device
                     self.named_devices[device['name']] = device
@@ -80,21 +81,21 @@ class EvohomeClient:
         self._populate_full_data()
         if self.gateway_data is None:
             url = 'https://tccna.honeywell.com/WebAPI/api/gateways?locationId=%s&allData=False' % self.location_id
-            response = requests.get(url, headers = self.headers)
-            
+            response = requests.get(url, headers=self.headers)
+
             self.gateway_data = self._convert(response.content)[0]
 
     def _populate_user_info(self):
         if self.user_data is None:
             url = 'https://tccna.honeywell.com/WebAPI/api/Session'
-            self.postdata = {'Username':self.username,'Password':self.password,'ApplicationId':'91db1612-73fd-4500-91b2-e63b069b185c'}
-            self.headers = {'content-type':'application/json'}
+            self.postdata = {'Username': self.username, 'Password': self.password, 'ApplicationId': '91db1612-73fd-4500-91b2-e63b069b185c'}
+            self.headers = {'content-type': 'application/json'}
 
-            response = requests.post(url,data=json.dumps(self.postdata),headers=self.headers)
+            response = requests.post(url, data=json.dumps(self.postdata), headers=self.headers)
             self.user_data = self._convert(response.content)
-            
+
         return self.user_data
-        
+
     def temperatures(self, force_refresh=False):
         self._populate_full_data(force_refresh)
         for device in self.full_data['devices']:
@@ -102,11 +103,10 @@ class EvohomeClient:
             if 'heatSetpoint' in device['thermostat']['changeableValues']:
                 setPoint = float(device['thermostat']['changeableValues']["heatSetpoint"]["value"])
             yield {'thermostat': device['thermostatModelType'],
-                    'id': device['deviceID'],
-                    'name': device['name'],
-                    'temp': float(device['thermostat']['indoorTemperature']),
-                   'setpoint':setPoint}
-
+                   'id': device['deviceID'],
+                   'name': device['name'],
+                   'temp': float(device['thermostat']['indoorTemperature']),
+                   'setpoint': setPoint}
 
     def get_modes(self, zone):
         self._populate_full_data()
@@ -124,41 +124,41 @@ class EvohomeClient:
         self._populate_full_data()
         url = 'https://tccna.honeywell.com/WebAPI/api/commTasks?commTaskId=%s' % task_id
         response = requests.get(url, headers=self.headers)
-        
+
         return self._convert(response.content)['state']
-    
+
     def _get_task_id(self, response):
         ret = self._convert(response.content)
-        
+
         if isinstance(ret, list):
             task_id = ret[0]['id']
         else:
             task_id = ret['id']
         return task_id
-        
+
     def _set_status(self, status, until=None):
         self._populate_full_data()
         url = 'https://tccna.honeywell.com/WebAPI/api/evoTouchSystems?locationId=%s' % self.location_id
         if until is None:
-            data = {"QuickAction":status,"QuickActionNextTime":None}
+            data = {"QuickAction": status, "QuickActionNextTime": None}
         else:
-            data = {"QuickAction":status,"QuickActionNextTime":"%sT00:00:00Z" % until.strftime('%Y-%m-%d')}
+            data = {"QuickAction": status, "QuickActionNextTime": "%sT00:00:00Z" % until.strftime('%Y-%m-%d')}
         response = requests.put(url, data=json.dumps(data), headers=self.headers)
-        
+
         task_id = self._get_task_id(response)
-        
+
         while self._get_task_status(task_id) != 'Succeeded':
             time.sleep(1)
 
     def set_status_normal(self):
         self._set_status('Auto')
-            
+
     def set_status_custom(self, until=None):
         self._set_status('Custom', until)
 
     def set_status_eco(self, until=None):
         self._set_status('AutoWithEco', until)
-        
+
     def set_status_away(self, until=None):
         self._set_status('Away', until)
 
@@ -171,65 +171,62 @@ class EvohomeClient:
     def _get_device_id(self, zone):
         device = self._get_device(zone)
         return device['deviceID']
-        
+
     def _set_heat_setpoint(self, zone, data):
         self._populate_full_data()
-        
+
         device_id = self._get_device_id(zone)
-        
+
         url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues/heatSetpoint' % device_id
         response = requests.put(url, json.dumps(data), headers=self.headers)
 
         task_id = self._get_task_id(response)
-        
+
         while self._get_task_status(task_id) != 'Succeeded':
             time.sleep(1)
-        
+
     def set_temperature(self, zone, temperature, until=None):
         if until is None:
-            data = {"Value":temperature,"Status":"Hold","NextTime":None}
+            data = {"Value": temperature, "Status": "Hold", "NextTime": None}
         else:
-            data = {"Value":temperature,"Status":"Temporary","NextTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"Value": temperature, "Status": "Temporary", "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_heat_setpoint(zone, data)
-        
-        
+
     def cancel_temp_override(self, zone):
-        data = {"Value":None,"Status":"Scheduled","NextTime":None}
+        data = {"Value": None, "Status": "Scheduled", "NextTime": None}
         self._set_heat_setpoint(zone, data)
-        
+
     def _get_dhw_zone(self):
         for device in self.full_data['devices']:
             if device['thermostatModelType'] == 'DOMESTIC_HOT_WATER':
                 return device['deviceID']
         return None
-        
+
     def _set_dhw(self, data):
         self._populate_full_data()
         url = 'https://tccna.honeywell.com/WebAPI/api/devices/%s/thermostat/changeableValues' % self._get_dhw_zone()
-        
+
         response = requests.put(url, data=json.dumps(data), headers=self.headers)
-        
+
         task_id = self._get_task_id(response)
-        
+
         while self._get_task_status(task_id) != 'Succeeded':
             time.sleep(1)
-        
+
     def set_dhw_on(self, until=None):
         if until is None:
-            data = {"Mode":"DHWOn","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":None}
+            data = {"Mode": "DHWOn", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": None}
         else:
-            data = {"Mode":"DHWOn","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"Mode": "DHWOn", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_off(self, until=None):
         if until is None:
-            data = {"Mode":"DHWOff","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":None}
+            data = {"Mode": "DHWOff", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": None}
         else:
-            data = {"Mode":"DHWOff","SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Hold","NextTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"Mode": "DHWOff", "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Hold", "NextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
-        
-        
+
     def set_dhw_auto(self):
-        data = {"Mode":None,"SpecialModes":None,"HeatSetpoint":None,"CoolSetpoint":None,"Status":"Scheduled","NextTime":None}
+        data = {"Mode": None, "SpecialModes": None, "HeatSetpoint": None, "CoolSetpoint": None, "Status": "Scheduled", "NextTime": None}
         self._set_dhw(data)
- 

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -114,7 +114,7 @@ class EvohomeClient:
         return device['thermostat']['allowedModes']
 
     def _get_device(self, zone):
-        if isinstance(zone, str) or (is_py2 and isinstance(zone, basestring)):
+        if isinstance(zone, str) or (is_py2 and isinstance(zone, basestring)):   # noqa: F821, E501
             device = self.named_devices[zone]
         else:
             device = self.devices[zone]

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -1,4 +1,7 @@
-"""evohomeclient is based on the original API for access to Evohome data"""
+"""evohomeclient2 provides a client for the oiginal Evohome API.
+
+   Further information at: https://evohome-client.readthedocs.io
+   """
 from __future__ import print_function
 
 import codecs
@@ -9,7 +12,8 @@ import sys
 import requests
 
 logging.basicConfig()
-REQUESTS_LOG = logging.getLogger("requests.packages.urllib3")
+_LOGGER = logging.getLogger(__name__)
+REQUESTS_LOGGER = logging.getLogger("requests.packages.urllib3")
 
 try:
     import http.client as http_client
@@ -53,15 +57,13 @@ class EvohomeClient:
         self.headers = {}
 
         if debug is True:
+            _LOGGER.setLevel(logging.DEBUG)
+            _LOGGER.debug("__init__(): Debug mode is explicitly enabled.")
+            REQUESTS_LOGGER.setLevel(logging.DEBUG)
+            REQUESTS_LOGGER.propagate = True
             http_client.HTTPConnection.debuglevel = 1
-            logging.getLogger(__name__).setLevel(logging.DEBUG)
-            REQUESTS_LOG.setLevel(logging.DEBUG)
-            REQUESTS_LOG.propagate = True
         else:
-            http_client.HTTPConnection.debuglevel = 0
-            logging.getLogger(__name__).setLevel(logging.INFO)
-            REQUESTS_LOG.setLevel(logging.INFO)
-            REQUESTS_LOG.propagate = False
+            _LOGGER.debug("__init__(): Debug mode was not explicitly enabled.")
 
     def _convert(self, content):
         return json.loads(self.reader(content)[0])

--- a/evohomeclient/tests.py
+++ b/evohomeclient/tests.py
@@ -1,0 +1,216 @@
+"""Tests for evohomeclient package"""
+import requests_mock
+from . import EvohomeClient
+
+VALID_SESSION_RESPONSE = '''{
+  "sessionId": "EE32E3A8-1C09-4A5C-9572-24A088197A38",
+  "userInfo": {
+    "userID": 123456,
+    "username": "username",
+    "firstname": "Forename",
+    "lastname": "Surname",
+    "streetAddress": "Street Address",
+    "city": "City",
+    "state": "",
+    "zipcode": "AB1 2CD",
+    "country": "GB",
+    "telephone": "",
+    "userLanguage": "en-GB",
+    "isActivated": true,
+    "deviceCount": 0,
+    "tenantID": 5,
+    "securityQuestion1": "NotUsed",
+    "securityQuestion2": "NotUsed",
+    "securityQuestion3": "NotUsed",
+    "latestEulaAccepted": false
+  }
+}'''
+
+VALID_ZONE_RESPONSE = '''[
+    {
+        "locationID": 23456,
+        "name": "Home",
+        "streetAddress": "Street Address",
+        "city": "City",
+        "state": "",
+        "country": "GB",
+        "zipcode": "AB1 2CD",
+        "type": "Residential",
+        "hasStation": true,
+        "devices": [
+        {
+            "gatewayId": 333444,
+            "deviceID": 131313,
+            "thermostatModelType": "DOMESTIC_HOT_WATER",
+            "deviceType": 96,
+            "name": "",
+            "scheduleCapable": false,
+            "holdUntilCapable": false,
+            "thermostat": {
+            "units": "Celsius",
+            "indoorTemperature": 24.0100,
+            "outdoorTemperature": 128.0000,
+            "outdoorTemperatureAvailable": false,
+            "outdoorHumidity": 128.0000,
+            "outdootHumidityAvailable": false,
+            "indoorHumidity": 128.0000,
+            "indoorTemperatureStatus": "Measured",
+            "indoorHumidityStatus": "NotAvailable",
+            "outdoorTemperatureStatus": "NotAvailable",
+            "outdoorHumidityStatus": "NotAvailable",
+            "isCommercial": false,
+            "allowedModes": [
+                "DHWOn",
+                "DHWOff"
+            ],
+            "deadband": 0.0000,
+            "minHeatSetpoint": 5.0000,
+            "maxHeatSetpoint": 30.0000,
+            "minCoolSetpoint": 50.0000,
+            "maxCoolSetpoint": 90.0000,
+            "changeableValues": {
+                "mode": "DHWOff",
+                "status": "Scheduled"
+            },
+            "scheduleCapable": false,
+            "vacationHoldChangeable": false,
+            "vacationHoldCancelable": false,
+            "scheduleHeatSp": 0.0000,
+            "scheduleCoolSp": 0.0000
+            },
+            "alertSettings": {
+            "deviceID": 131313,
+            "tempHigherThanActive": false,
+            "tempHigherThan": 100.0000,
+            "tempHigherThanMinutes": 0,
+            "tempLowerThanActive": false,
+            "tempLowerThan": -50.0000,
+            "tempLowerThanMinutes": 0,
+            "faultConditionExistsActive": false,
+            "faultConditionExistsHours": 0,
+            "normalConditionsActive": true,
+            "communicationLostActive": false,
+            "communicationLostHours": 0,
+            "thermostatAlertActive": false,
+            "communicationFailureActive": true,
+            "communicationFailureMinutes": 15,
+            "deviceLostActive": false,
+            "deviceLostHours": 0
+            },
+            "isUpgrading": false,
+            "isAlive": true,
+            "thermostatVersion": "03.00.10.06",
+            "macID": "001122334455",
+            "locationID": 23456,
+            "domainID": 28111,
+            "instance": 250
+        },
+        {
+            "gatewayId": 333444,
+            "deviceID": 121212,
+            "thermostatModelType": "EMEA_ZONE",
+            "deviceType": 96,
+            "name": "RoomName",
+            "scheduleCapable": false,
+            "holdUntilCapable": false,
+            "thermostat": {
+            "units": "Celsius",
+            "indoorTemperature": 17.5400,
+            "outdoorTemperature": 128.0000,
+            "outdoorTemperatureAvailable": false,
+            "outdoorHumidity": 128.0000,
+            "outdootHumidityAvailable": false,
+            "indoorHumidity": 128.0000,
+            "indoorTemperatureStatus": "Measured",
+            "indoorHumidityStatus": "NotAvailable",
+            "outdoorTemperatureStatus": "NotAvailable",
+            "outdoorHumidityStatus": "NotAvailable",
+            "isCommercial": false,
+            "allowedModes": [
+                "Heat",
+                "Off"
+            ],
+            "deadband": 0.0000,
+            "minHeatSetpoint": 5.0000,
+            "maxHeatSetpoint": 35.0000,
+            "minCoolSetpoint": 50.0000,
+            "maxCoolSetpoint": 90.0000,
+            "changeableValues": {
+                "mode": "Off",
+                "heatSetpoint": {
+                "value": 15.0,
+                "status": "Scheduled"
+                },
+                "vacationHoldDays": 0
+            },
+            "scheduleCapable": false,
+            "vacationHoldChangeable": false,
+            "vacationHoldCancelable": false,
+            "scheduleHeatSp": 0.0000,
+            "scheduleCoolSp": 0.0000
+            },
+            "alertSettings": {
+            "deviceID": 121212,
+            "tempHigherThanActive": true,
+            "tempHigherThan": 30.0000,
+            "tempHigherThanMinutes": 0,
+            "tempLowerThanActive": true,
+            "tempLowerThan": 5.0000,
+            "tempLowerThanMinutes": 0,
+            "faultConditionExistsActive": false,
+            "faultConditionExistsHours": 0,
+            "normalConditionsActive": true,
+            "communicationLostActive": false,
+            "communicationLostHours": 0,
+            "communicationFailureActive": true,
+            "communicationFailureMinutes": 15,
+            "deviceLostActive": false,
+            "deviceLostHours": 0
+            },
+            "isUpgrading": false,
+            "isAlive": true,
+            "thermostatVersion": "03.00.10.06",
+            "macID": "001122334455",
+            "locationID": 23456,
+            "domainID": 28111,
+            "instance": 10
+        }
+        ]
+    }
+    ]'''
+
+
+@requests_mock.Mocker()
+def test_429_returned_raises_exception(mock):
+    """test that exception is raised for a 429 error"""
+    mock.post('http://localhost:5050/WebAPI/api/Session', status_code=429, text='''[
+  {
+    "code": "TooManyRequests",
+    "message": "Request count limitation exceeded, please try again later."
+  }
+]''')
+
+    try:
+        client = EvohomeClient("username", "password",
+                               hostname="http://localhost:5050")
+        list(client.temperatures())
+        # Shouldn't get here
+        assert False
+    # pylint: disable=bare-except
+    except:
+        assert True
+
+
+@requests_mock.Mocker()
+def test_valid_login(mock):
+    """test valid path"""
+    mock.post('http://localhost:5050/WebAPI/api/Session', text=VALID_SESSION_RESPONSE)
+    mock.get('http://localhost:5050/WebAPI/api/locations?userId=123456&allData=True', text=VALID_ZONE_RESPONSE)
+
+    client = EvohomeClient("username", "password",
+                           hostname="http://localhost:5050")
+    data = list(client.temperatures())
+
+    assert len(data) == 2
+    # assert x[1].name == "RoomName"
+    assert data == [{'thermostat': 'DOMESTIC_HOT_WATER', 'id': 131313, 'name': '', 'temp': 24.01, 'setpoint': 0}, {'thermostat': 'EMEA_ZONE', 'id': 121212, 'name': 'RoomName', 'temp': 17.54, 'setpoint': 15.0}]

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -1,4 +1,7 @@
-"""Provides a client for the updated Evohome API"""
+"""evohomeclient2 provides a client for the updated Evohome API.
+
+   Further information at: https://evohome-client.readthedocs.io
+   """
 from __future__ import print_function
 from datetime import datetime, timedelta
 import requests

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -29,23 +29,17 @@ class EvohomeClient(EvohomeBase):  # pylint: disable=too-many-instance-attribute
                  access_token=None, access_token_expires=None):
         super(EvohomeClient, self).__init__(debug)
 
-        self.access_token = None
-        self.access_token_expires = None
         self.username = username
         self.password = password
-        self.account_info = None
-        self.locations = []
-        self.installation_info = {}
-        self.system_id = ""
 
+        self.refresh_token = refresh_token
         self.access_token = access_token
         self.access_token_expires = access_token_expires
-        self.refresh_token = refresh_token
 
         self.account_info = None
-        self.system_id = None
         self.locations = None
         self.installation_info = None
+        self.system_id = None
 
         self._login()
 
@@ -162,41 +156,6 @@ class EvohomeClient(EvohomeBase):  # pylint: disable=too-many-instance-attribute
             raise Exception("More than one control system available")
 
         return control_system
-
-    def _basic_login(self):
-        self.access_token = None
-        self.access_token_expires = None
-
-        url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
-        headers = {
-            'Authorization':	'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
-            'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
-        }
-        data = {
-            'Content-Type':	'application/x-www-form-urlencoded; charset=utf-8',
-            'Host':	'rs.alarmnet.com/',
-            'Cache-Control': 'no-store no-cache',
-            'Pragma':	'no-cache',
-            'grant_type':	'password',
-            'scope':	'EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account',
-            'Username':	self.username,
-            'Password':	self.password,
-            'Connection':	'Keep-Alive'
-        }
-        response = requests.post(url, data=data, headers=headers)
-
-        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
-            response.raise_for_status()
-
-        data = self._convert(response.text)
-        self.access_token = data['access_token']
-        self.access_token_expires = datetime.now(
-        ) + timedelta(seconds=data['expires_in'])
-
-    def _login(self):
-        self._basic_login()
-        self.user_account()
-        self.installation()
 
     def user_account(self):
         """Gets user account information"""

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -16,13 +16,6 @@ class EvohomeClient(EvohomeBase):
         self.access_token = access_token
         self.access_token_expires = access_token_expires
 
-        # If previous details are provided, we also need to initialise the _headers object
-        if self.access_token is not None:
-            self._headers = {
-                'Authorization': 'bearer ' + self.access_token,
-                'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
-            }
-
         self._login()
 
     def _get_location(self, location):
@@ -82,11 +75,6 @@ class EvohomeClient(EvohomeBase):
         data = self._convert(r.text)
         self.access_token = data['access_token']
         self.access_token_expires = datetime.now() + timedelta(seconds = data['expires_in'])
-
-        self._headers = {
-            'Authorization': 'bearer ' + self.access_token,
-            'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
-        }
         
     def _login(self):
         self.user_account()
@@ -99,6 +87,12 @@ class EvohomeClient(EvohomeBase):
         elif datetime.now() > self.access_token_expires - timedelta(seconds = 30):
         # token has expired
             self._basic_login()
+        
+        self._headers = {
+            'Authorization': 'bearer ' + self.access_token,
+            'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
+        }
+
         return self._headers
 
     def user_account(self):

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -7,11 +7,21 @@ from .location import Location
 from .base import EvohomeBase
 
 class EvohomeClient(EvohomeBase):
-    def __init__(self, username, password, debug=False):
+    def __init__(self, username, password, debug=False, access_token=None, access_token_expires=None):
         super(EvohomeClient, self).__init__(debug)
 
         self.username = username
         self.password = password
+
+        self.access_token = access_token
+        self.access_token_expires = access_token_expires
+
+        # If previous details are provided, we also need to initialise the _headers object
+        if self.access_token is not None:
+            self._headers = {
+                'Authorization': 'bearer ' + self.access_token,
+                'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
+            }
 
         self._login()
 
@@ -79,7 +89,6 @@ class EvohomeClient(EvohomeBase):
         }
         
     def _login(self):
-        self._basic_login()
         self.user_account()
         self.installation()
 

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -1,3 +1,4 @@
+"""Provides a client for the updated Evohome API"""
 from __future__ import print_function
 from datetime import datetime, timedelta
 import requests
@@ -20,13 +21,22 @@ HEADER_BASIC_AUTH = {
 }
 
 
-class EvohomeClient(EvohomeBase):
+class EvohomeClient(EvohomeBase):  # pylint: disable=too-many-instance-attributes
+    """Provides access to the Evohome API"""
+
+    # pylint: disable=too-many-arguments
     def __init__(self, username, password, debug=False, refresh_token=None,
                  access_token=None, access_token_expires=None):
         super(EvohomeClient, self).__init__(debug)
 
+        self.access_token = None
+        self.access_token_expires = None
         self.username = username
         self.password = password
+        self.account_info = None
+        self.locations = []
+        self.installation_info = {}
+        self.system_id = ""
 
         self.access_token = access_token
         self.access_token_expires = access_token_expires
@@ -103,7 +113,8 @@ class EvohomeClient(EvohomeBase):
             if 'error' in response_json:
                 if response_json['error'] == 'invalid_grant':
                     return False
-            raise requests.HTTPError("Unable to obtain an Access Token: ", response_json)
+            raise requests.HTTPError(
+                "Unable to obtain an Access Token: ", response_json)
 
         response.raise_for_status()
 
@@ -112,7 +123,8 @@ class EvohomeClient(EvohomeBase):
 
             # these may cause a KeyError
             self.access_token = response_json['access_token']
-            self.access_token_expires = (datetime.now() + timedelta(seconds=response_json['expires_in']))
+            self.access_token_expires = (
+                datetime.now() + timedelta(seconds=response_json['expires_in']))
             self.refresh_token = response_json['refresh_token']
 
         except KeyError as error:
@@ -139,19 +151,55 @@ class EvohomeClient(EvohomeBase):
         else:
             raise Exception("More than one location available")
 
-        if len(location._gateways) == 1:                                         # pylint: disable=protected-access
-            gateway = location._gateways[0]                                      # pylint: disable=protected-access
+        if len(location._gateways) == 1:  # pylint: disable=protected-access
+            gateway = location._gateways[0]  # pylint: disable=protected-access
         else:
             raise Exception("More than one gateway available")
 
-        if len(gateway._control_systems) == 1:                                   # pylint: disable=protected-access
-            control_system = gateway._control_systems[0]                         # pylint: disable=protected-access
+        if len(gateway._control_systems) == 1:  # pylint: disable=protected-access
+            control_system = gateway._control_systems[0]  # pylint: disable=protected-access
         else:
             raise Exception("More than one control system available")
 
         return control_system
 
+    def _basic_login(self):
+        self.access_token = None
+        self.access_token_expires = None
+
+        url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
+        headers = {
+            'Authorization':	'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
+            'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
+        }
+        data = {
+            'Content-Type':	'application/x-www-form-urlencoded; charset=utf-8',
+            'Host':	'rs.alarmnet.com/',
+            'Cache-Control': 'no-store no-cache',
+            'Pragma':	'no-cache',
+            'grant_type':	'password',
+            'scope':	'EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account',
+            'Username':	self.username,
+            'Password':	self.password,
+            'Connection':	'Keep-Alive'
+        }
+        response = requests.post(url, data=data, headers=headers)
+
+        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+            response.raise_for_status()
+
+        data = self._convert(response.text)
+        self.access_token = data['access_token']
+        self.access_token_expires = datetime.now(
+        ) + timedelta(seconds=data['expires_in'])
+
+    def _login(self):
+        self._basic_login()
+        self.user_account()
+        self.installation()
+
     def user_account(self):
+        """Gets user account information"""
         self.account_info = None
 
         url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount'
@@ -163,6 +211,7 @@ class EvohomeClient(EvohomeBase):
         return self.account_info
 
     def installation(self):
+        """Returns details of the installation"""
         self.locations = []
 
         url = ("https://tccna.honeywell.com/WebAPI/emea/api/v1/location"
@@ -182,6 +231,7 @@ class EvohomeClient(EvohomeBase):
         return self.installation_info
 
     def full_installation(self, location=None):
+        """Retrieves full details of the installation"""
         url = ("https://tccna.honeywell.com/WebAPI/emea/api/v1/location"
                "/%s/installationInfo?includeTemperatureControlSystems=True"
                % self._get_location(location))
@@ -192,6 +242,7 @@ class EvohomeClient(EvohomeBase):
         return response.json()
 
     def gateway(self):
+        """Retrieves details of the gateway"""
         url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/gateway'
 
         response = requests.get(url, headers=self._headers())
@@ -200,31 +251,41 @@ class EvohomeClient(EvohomeBase):
         return response.json()
 
     def set_status_normal(self):
+        """Sets the system into normal heating mode"""
         return self._get_single_heating_system().set_status_normal()
 
     def set_status_reset(self):
+        """Resets the system mode"""
         return self._get_single_heating_system().set_status_reset()
 
     def set_status_custom(self, until=None):
+        """Sets the system into custom heating mode"""
         return self._get_single_heating_system().set_status_custom(until)
 
     def set_status_eco(self, until=None):
+        """Sets the system into eco heating mode"""
         return self._get_single_heating_system().set_status_eco(until)
 
     def set_status_away(self, until=None):
+        """Sets the system into away heating mode"""
         return self._get_single_heating_system().set_status_away(until)
 
     def set_status_dayoff(self, until=None):
+        """Sets the system into day off heating mode"""
         return self._get_single_heating_system().set_status_dayoff(until)
 
     def set_status_heatingoff(self, until=None):
+        """Sets the system into heating off heating mode"""
         return self._get_single_heating_system().set_status_heatingoff(until)
 
     def temperatures(self):
+        """Returns the current zone temperatures and set points"""
         return self._get_single_heating_system().temperatures()
 
     def zone_schedules_backup(self, filename):
+        """Backs up the current system configuration to the given file"""
         return self._get_single_heating_system().zone_schedules_backup(filename)
 
     def zone_schedules_restore(self, filename):
+        """Restores the current system configuration from the given file"""
         return self._get_single_heating_system().zone_schedules_restore(filename)

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -6,6 +6,7 @@ from datetime import datetime, timedelta
 from .location import Location
 from .base import EvohomeBase
 
+
 class EvohomeClient(EvohomeBase):
     def __init__(self, username, password, debug=False, access_token=None, access_token_expires=None):
         super(EvohomeClient, self).__init__(debug)
@@ -29,43 +30,43 @@ class EvohomeClient(EvohomeBase):
         location = None
         gateway = None
         control_system = None
-        
-        if len(self.locations)==1:
+
+        if len(self.locations) == 1:
             location = self.locations[0]
         else:
             raise Exception("More than one location available")
-            
-        if len(location._gateways)==1:
+
+        if len(location._gateways) == 1:
             gateway = location._gateways[0]
         else:
             raise Exception("More than one gateway available")
-            
-        if len(gateway._control_systems)==1:
+
+        if len(gateway._control_systems) == 1:
             control_system = gateway._control_systems[0]
         else:
             raise Exception("More than one control system available")
-            
+
         return control_system
-        
+
     def _basic_login(self):
         self.access_token = None
         self.access_token_expires = None
 
         url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
         headers = {
-            'Authorization':	'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
+            'Authorization': 'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
             'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
         }
         data = {
-            'Content-Type':	'application/x-www-form-urlencoded; charset=utf-8',
-            'Host':	'rs.alarmnet.com/',
-            'Cache-Control':'no-store no-cache',
-            'Pragma':	'no-cache',
-            'grant_type':	'password',
-            'scope':	'EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account',
-            'Username':	self.username,
-            'Password':	self.password,
-            'Connection':	'Keep-Alive'
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+            'Host': 'rs.alarmnet.com/',
+            'Cache-Control': 'no-store no-cache',
+            'Pragma': 'no-cache',
+            'grant_type': 'password',
+            'scope': 'EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account',
+            'Username': self.username,
+            'Password': self.password,
+            'Connection': 'Keep-Alive'
         }
         r = requests.post(url, data=data, headers=headers)
 
@@ -74,20 +75,20 @@ class EvohomeClient(EvohomeBase):
 
         data = self._convert(r.text)
         self.access_token = data['access_token']
-        self.access_token_expires = datetime.now() + timedelta(seconds = data['expires_in'])
-        
+        self.access_token_expires = datetime.now() + timedelta(seconds=data['expires_in'])
+
     def _login(self):
         self.user_account()
         self.installation()
 
     def headers(self):
         if self.access_token is None or self.access_token_expires is None:
-        # token is invalid
+            # token is invalid
             self._basic_login()
-        elif datetime.now() > self.access_token_expires - timedelta(seconds = 30):
-        # token has expired
+        elif datetime.now() > self.access_token_expires - timedelta(seconds=30):
+            # token has expired
             self._basic_login()
-        
+
         self._headers = {
             'Authorization': 'bearer ' + self.access_token,
             'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
@@ -160,7 +161,7 @@ class EvohomeClient(EvohomeBase):
 
     def temperatures(self):
         return self._get_single_heating_system().temperatures()
-    
+
     def zone_schedules_backup(self, filename):
         return self._get_single_heating_system().zone_schedules_backup(filename)
 

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -1,12 +1,24 @@
 from __future__ import print_function
-import requests
 from datetime import datetime, timedelta
+import requests
+
 from .location import Location
 from .base import EvohomeBase
 
+HEADER_ACCEPT = (
+    "application/json, application/xml, text/json, text/x-json, "
+    "text/javascript, text/xml"
+)
+HEADER_AUTHORIZATION_BASIC = (
+    "Basic "
+    "NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Y"
+    "i1hZGQwLTA1OWY5MmM1MzBjYg=="
+)
+
 
 class EvohomeClient(EvohomeBase):
-    def __init__(self, username, password, debug=False, access_token=None, access_token_expires=None):
+    def __init__(self, username, password, debug=False, refresh_token=None,
+                 access_token=None, access_token_expires=None):
         super(EvohomeClient, self).__init__(debug)
 
         self.username = username
@@ -14,14 +26,94 @@ class EvohomeClient(EvohomeBase):
 
         self.access_token = access_token
         self.access_token_expires = access_token_expires
+        self.refresh_token = refresh_token
+
+        self.account_info = None
+        self.system_id = None
+        self.locations = None
+        self.installation_info = None
 
         self._login()
+
+    def _login(self):
+        self.user_account()
+        self.installation()
+
+    def _headers(self):
+        """Ensure the Authorization Header has a valid Access Token."""
+
+        if self.access_token is None or self.access_token_expires is None:
+            self._basic_login()
+
+        elif datetime.now() > self.access_token_expires - timedelta(seconds=30):
+            self._basic_login()
+
+        return {'Accept': HEADER_ACCEPT,
+                'Authorization': 'bearer ' + self.access_token}
+
+    def _basic_login(self):
+        """Obtain an access token from the vendor.
+
+        First, try using the refresh_token, if one is provided, otherwise
+        authenticate using the user credentials."""
+
+        self.access_token = None
+        self.access_token_expires = None
+
+        if self.refresh_token is not None:
+            credentials = {'grant_type': "refresh_token",
+                           'scope': "EMEA-V1-Basic EMEA-V1-Anonymous",
+                           'refresh_token': self.refresh_token}
+
+            if not self._obtain_access_token(credentials):
+                self.refresh_token = None
+
+        if self.refresh_token is None:
+            credentials = {'grant_type': "password",
+                           'scope': "EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account",
+                           'Username': self.username,
+                           'Password': self.password}
+
+            self._obtain_access_token(credentials)
+
+    def _obtain_access_token(self, credentials):
+        """Get an access token using the supplied credentials."""
+
+        url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
+        headers = {
+            'Accept': HEADER_ACCEPT,
+            'Authorization': HEADER_AUTHORIZATION_BASIC
+        }
+        data = {
+            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
+            'Host': 'rs.alarmnet.com/',
+            'Cache-Control': 'no-store no-cache',
+            'Pragma': 'no-cache',
+            'Connection': 'Keep-Alive'
+        }
+        data.update(credentials)
+
+        response = requests.post(url, data=data, headers=headers)
+        if response.status_code != requests.codes.ok:                            # pylint: disable=no-member
+            response.raise_for_status()
+
+        try:  # validate the access token
+            tokens = self._convert(response.text)
+
+            self.access_token = tokens['access_token']
+            self.access_token_expires = (datetime.now() + timedelta(seconds=tokens['expires_in']))
+            if credentials['grant_type'] == "password":
+                self.refresh_token = tokens['refresh_token']
+
+        except KeyError:
+            return False
+
+        return True
 
     def _get_location(self, location):
         if location is None:
             return self.installation_info[0]['locationInfo']['locationId']
-        else:
-            return location
+        return location
 
     def _get_single_heating_system(self):
         # This allows a shortcut for some systems
@@ -34,86 +126,43 @@ class EvohomeClient(EvohomeBase):
         else:
             raise Exception("More than one location available")
 
-        if len(location._gateways) == 1:
-            gateway = location._gateways[0]
+        if len(location._gateways) == 1:                                         # pylint: disable=protected-access
+            gateway = location._gateways[0]                                      # pylint: disable=protected-access
         else:
             raise Exception("More than one gateway available")
 
-        if len(gateway._control_systems) == 1:
-            control_system = gateway._control_systems[0]
+        if len(gateway._control_systems) == 1:                                   # pylint: disable=protected-access
+            control_system = gateway._control_systems[0]                         # pylint: disable=protected-access
         else:
             raise Exception("More than one control system available")
 
         return control_system
 
-    def _basic_login(self):
-        self.access_token = None
-        self.access_token_expires = None
-
-        url = 'https://tccna.honeywell.com/Auth/OAuth/Token'
-        headers = {
-            'Authorization': 'Basic NGEyMzEwODktZDJiNi00MWJkLWE1ZWItMTZhMGE0MjJiOTk5OjFhMTVjZGI4LTQyZGUtNDA3Yi1hZGQwLTA1OWY5MmM1MzBjYg==',
-            'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
-        }
-        data = {
-            'Content-Type': 'application/x-www-form-urlencoded; charset=utf-8',
-            'Host': 'rs.alarmnet.com/',
-            'Cache-Control': 'no-store no-cache',
-            'Pragma': 'no-cache',
-            'grant_type': 'password',
-            'scope': 'EMEA-V1-Basic EMEA-V1-Anonymous EMEA-V1-Get-Current-User-Account',
-            'Username': self.username,
-            'Password': self.password,
-            'Connection': 'Keep-Alive'
-        }
-        r = requests.post(url, data=data, headers=headers)
-
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
-
-        data = self._convert(r.text)
-
-        self.refresh_token = data['refresh_token']
-        self.access_token = data['access_token']
-        self.access_token_expires = datetime.now() + timedelta(seconds=data['expires_in'])
-
-    def _login(self):
-        self.user_account()
-        self.installation()
-
-    def headers(self):
-        if self.access_token is None or self.access_token_expires is None:
-            # token is invalid
-            self._basic_login()
-        elif datetime.now() > self.access_token_expires - timedelta(seconds=30):
-            # token has expired
-            self._basic_login()
-
-        self._headers = {
-            'Authorization': 'bearer ' + self.access_token,
-            'Accept': 'application/json, application/xml, text/json, text/x-json, text/javascript, text/xml'
-        }
-
-        return self._headers
-
     def user_account(self):
         self.account_info = None
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount', headers=self.headers())
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount'
 
-        self.account_info = self._convert(r.text)
+        response = requests.get(url, headers=self._headers())
+        if response.status_code != requests.codes.ok:                            # pylint: disable=no-member
+            response.raise_for_status()
+
+        self.account_info = self._convert(response.text)
         return self.account_info
 
     def installation(self):
         self.locations = []
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=%s&includeTemperatureControlSystems=True' % self.account_info['userId'], headers=self.headers())
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        url = ("https://tccna.honeywell.com/WebAPI/emea/api/v1/location"
+               "/installationInfo?userId=%s"
+               "&includeTemperatureControlSystems=True"
+               % self.account_info['userId'])
 
-        self.installation_info = self._convert(r.text)
+        response = requests.get(url, headers=self._headers())
+        if response.status_code != requests.codes.ok:                            # pylint: disable=no-member
+            response.raise_for_status()
+
+        self.installation_info = self._convert(response.text)
         self.system_id = self.installation_info[0]['gateways'][0]['temperatureControlSystems'][0]['systemId']
 
         for loc_data in self.installation_info:
@@ -122,21 +171,24 @@ class EvohomeClient(EvohomeBase):
         return self.installation_info
 
     def full_installation(self, location=None):
-        location = self._get_location(location)
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/installationInfo?includeTemperatureControlSystems=True' % location, headers=self.headers())
+        url = ("https://tccna.honeywell.com/WebAPI/emea/api/v1/location"
+               "/%s/installationInfo?includeTemperatureControlSystems=True"
+               % self._get_location(location))
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        response = requests.get(url, headers=self._headers())
+        if response.status_code != requests.codes.ok:                            # pylint: disable=no-member
+            response.raise_for_status()
 
-        return self._convert(r.text)
+        return self._convert(response.text)
 
     def gateway(self):
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/gateway', headers=self.headers())
+        url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/gateway'
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        response = requests.get(url, headers=self._headers())
+        if response.status_code != requests.codes.ok:                            # pylint: disable=no-member
+            response.raise_for_status()
 
-        return self._convert(r.text)
+        return self._convert(response.text)
 
     def set_status_normal(self):
         return self._get_single_heating_system().set_status_normal()

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -1,7 +1,5 @@
 from __future__ import print_function
 import requests
-import json
-import codecs
 from datetime import datetime, timedelta
 from .location import Location
 from .base import EvohomeBase
@@ -74,6 +72,8 @@ class EvohomeClient(EvohomeBase):
             r.raise_for_status()
 
         data = self._convert(r.text)
+
+        self.refresh_token = data['refresh_token']
         self.access_token = data['access_token']
         self.access_token_expires = datetime.now() + timedelta(seconds=data['expires_in'])
 

--- a/evohomeclient2/base.py
+++ b/evohomeclient2/base.py
@@ -2,8 +2,10 @@
 import json
 import codecs
 import logging
+
 logging.basicConfig()
-REQUESTS_LOG = logging.getLogger("requests.packages.urllib3")
+_LOGGER = logging.getLogger(__name__)
+REQUESTS_LOGGER = logging.getLogger("requests.packages.urllib3")
 
 try:
     import http.client as http_client
@@ -22,16 +24,14 @@ class EvohomeBase(object):  # pylint: disable=too-few-public-methods
     def __init__(self, debug=False):
         self.reader = codecs.getdecoder("utf-8")
 
-        if debug:
+        if debug is True:
+            _LOGGER.setLevel(logging.DEBUG)
+            _LOGGER.debug("__init__(): Debug mode is explicitly enabled.")
+            REQUESTS_LOGGER.setLevel(logging.DEBUG)
+            REQUESTS_LOGGER.propagate = True
             http_client.HTTPConnection.debuglevel = 1
-            logging.getLogger(__name__).setLevel(logging.DEBUG)
-            REQUESTS_LOG.setLevel(logging.DEBUG)
-            REQUESTS_LOG.propagate = True
         else:
-            http_client.HTTPConnection.debuglevel = 0
-            logging.getLogger(__name__).setLevel(logging.INFO)
-            REQUESTS_LOG.setLevel(logging.INFO)
-            REQUESTS_LOG.propagate = False
+            _LOGGER.debug("__init__(): Debug mode was not explicitly enabled.")
 
     def _convert(self, obj):  # pylint: disable=no-self-use
         return json.loads(obj)

--- a/evohomeclient2/base.py
+++ b/evohomeclient2/base.py
@@ -10,13 +10,15 @@ except ImportError:
     # Python 2
     import httplib as http_client
 
+
 class EvohomeClientInvalidPostData(Exception):
     pass
+
 
 class EvohomeBase(object):
     def __init__(self, debug=False):
         self.reader = codecs.getdecoder("utf-8")
-        
+
         if debug:
             http_client.HTTPConnection.debuglevel = 1
             logging.getLogger(__name__).setLevel(logging.DEBUG)
@@ -27,6 +29,6 @@ class EvohomeBase(object):
             logging.getLogger(__name__).setLevel(logging.INFO)
             requests_log.setLevel(logging.INFO)
             requests_log.propagate = False
-    
+
     def _convert(self, object):
         return json.loads(object)

--- a/evohomeclient2/base.py
+++ b/evohomeclient2/base.py
@@ -1,8 +1,9 @@
+"""Provide base capability for evohomeclient"""
 import json
 import codecs
 import logging
 logging.basicConfig()
-requests_log = logging.getLogger("requests.packages.urllib3")
+REQUESTS_LOG = logging.getLogger("requests.packages.urllib3")
 
 try:
     import http.client as http_client
@@ -12,23 +13,25 @@ except ImportError:
 
 
 class EvohomeClientInvalidPostData(Exception):
-    pass
+    """Used when data has been incorrectly sent"""
 
 
-class EvohomeBase(object):
+class EvohomeBase(object):  # pylint: disable=too-few-public-methods
+    """Base class for evohomeclient"""
+
     def __init__(self, debug=False):
         self.reader = codecs.getdecoder("utf-8")
 
         if debug:
             http_client.HTTPConnection.debuglevel = 1
             logging.getLogger(__name__).setLevel(logging.DEBUG)
-            requests_log.setLevel(logging.DEBUG)
-            requests_log.propagate = True
+            REQUESTS_LOG.setLevel(logging.DEBUG)
+            REQUESTS_LOG.propagate = True
         else:
             http_client.HTTPConnection.debuglevel = 0
             logging.getLogger(__name__).setLevel(logging.INFO)
-            requests_log.setLevel(logging.INFO)
-            requests_log.propagate = False
+            REQUESTS_LOG.setLevel(logging.INFO)
+            REQUESTS_LOG.propagate = False
 
-    def _convert(self, object):
-        return json.loads(object)
+    def _convert(self, obj):  # pylint: disable=no-self-use
+        return json.loads(obj)

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -3,7 +3,7 @@ import requests
 
 from .zone import Zone
 from .hotwater import HotWater
-from .base import EvohomeBase, EvohomeClientInvalidPostData
+from .base import EvohomeBase
 
 
 class ControlSystem(EvohomeBase):
@@ -71,8 +71,6 @@ class ControlSystem(EvohomeBase):
         self._set_status("HeatingOff", until)
 
     def temperatures(self):
-        status = self.location.status()
-
         if self.hotwater:
             yield {'thermostat': 'DOMESTIC_HOT_WATER',
                    'id': self.hotwater.dhwId,

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -1,3 +1,5 @@
+"""Provides handling of a control system"""
+from __future__ import print_function
 import json
 import requests
 
@@ -7,6 +9,7 @@ from .base import EvohomeBase
 
 
 class ControlSystem(EvohomeBase):
+    """Provides handling of a control system"""
 
     def __init__(self, client, location, gateway, data=None):
         super(ControlSystem, self).__init__()
@@ -25,97 +28,114 @@ class ControlSystem(EvohomeBase):
 
             self.__dict__.update(local_data)
 
-            for i, z_data in enumerate(data['zones']):
+            for _, z_data in enumerate(data['zones']):
                 zone = Zone(client, z_data)
                 self._zones.append(zone)
-                self.zones[zone.name] = zone
-                self.zones_by_id[zone.zoneId] = zone
+                self.zones[zone.name] = zone   # pylint: disable=no-member
+                self.zones_by_id[zone.zoneId] = zone  # pylint: disable=no-member
 
             if 'dhw' in data:
                 self.hotwater = HotWater(client, data['dhw'])
 
     def _set_status(self, mode, until=None):
 
+        # pylint: disable=no-member,protected-access
         headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
 
         if until is None:
             data = {"SystemMode": mode, "TimeUntil": None, "Permanent": True}
         else:
-            data = {"SystemMode": mode, "TimeUntil": "%sT00:00:00Z" % until.strftime('%Y-%m-%d'), "Permanent": False}
+            data = {
+                "SystemMode": mode,
+                "TimeUntil": "%sT00:00:00Z" % until.strftime('%Y-%m-%d'),
+                "Permanent": False
+            }
 
-        r = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureControlSystem/%s/mode' % self.systemId, data=json.dumps(data), headers=headers)
+        response = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureControlSystem/%s/mode' %
+                                self.systemId, data=json.dumps(data), headers=headers)  # pylint: disable=no-member
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+            response.raise_for_status()
 
     def set_status_normal(self):
+        """Sets the system into normal mode"""
         self._set_status("Auto")
 
     def set_status_reset(self):
+        """Resets the system into normal mode"""
         self._set_status("AutoWithReset")
 
     def set_status_custom(self, until=None):
+        """Sets the system into custom mode"""
         self._set_status("Custom", until)
 
     def set_status_eco(self, until=None):
+        """Sets the system into eco mode"""
         self._set_status("AutoWithEco", until)
 
     def set_status_away(self, until=None):
+        """Sets the system into away mode"""
         self._set_status("Away", until)
 
     def set_status_dayoff(self, until=None):
+        """Sets the system into dayoff mode"""
         self._set_status("DayOff", until)
 
     def set_status_heatingoff(self, until=None):
+        """Sets the system into heating off mode"""
         self._set_status("HeatingOff", until)
 
     def temperatures(self):
+        """Returns a generator with the details of each zone"""
         if self.hotwater:
             yield {'thermostat': 'DOMESTIC_HOT_WATER',
-                   'id': self.hotwater.dhwId,
+                   'id': self.hotwater.dhwId,  # pylint: disable=no-member
                    'name': '',
-                   'temp': self.hotwater.temperatureStatus['temperature'],
+                   'temp': self.hotwater.temperatureStatus['temperature'],  # pylint: disable=no-member
                    'setpoint': ''}
 
         for zone in self._zones:
-            z = {'thermostat': 'EMEA_ZONE',
-                 'id': zone.zoneId,
-                 'name': zone.name,
-                 'temp': None,
-                 'setpoint': zone.setpointStatus['targetHeatTemperature']}
+            zone_info = {'thermostat': 'EMEA_ZONE',
+                         'id': zone.zoneId,
+                         'name': zone.name,
+                         'temp': None,
+                         'setpoint': zone.setpointStatus['targetHeatTemperature']}
             if zone.temperatureStatus['isAvailable']:
-                z['temp'] = zone.temperatureStatus['temperature']
-            yield z
+                zone_info['temp'] = zone.temperatureStatus['temperature']
+            yield zone_info
 
     def zone_schedules_backup(self, filename):
+        """Backs up all zones on control system to the given file"""
         print("Backing up zone schedule to: %s" % (filename))
 
         schedules = {}
 
         if self.hotwater:
             print("Retrieving DHW schedule: %s" % self.hotwater.zoneId)
-            s = self.hotwater.schedule()
-            schedules[self.hotwater.zoneId] = {'name': 'Domestic Hot Water', 'schedule': s}
+            schedule = self.hotwater.schedule()
+            schedules[self.hotwater.zoneId] = {
+                'name': 'Domestic Hot Water', 'schedule': schedule}
 
-        for z in self._zones:
-            zone_id = z.zoneId
-            name = z.name
+        for zone in self._zones:
+            zone_id = zone.zoneId
+            name = zone.name
             print("Retrieving zone schedule: %s - %s" % (zone_id, name))
-            s = z.schedule()
-            schedules[zone_id] = {'name': name, 'schedule': s}
+            schedule = zone.schedule()
+            schedules[zone_id] = {'name': name, 'schedule': schedule}
 
         schedule_db = json.dumps(schedules, indent=4)
 
-        with open(filename, 'w') as f:
-            f.write(schedule_db)
+        with open(filename, 'w') as file_output:
+            file_output.write(schedule_db)
 
         print("Backed up zone schedule to: %s" % filename)
 
     def zone_schedules_restore(self, filename):
+        """Restores all zones on control system from the given file"""
         print("Restoring zone schedules from: %s" % filename)
-        with open(filename, 'r') as f:
-            schedule_db = f.read()
+        with open(filename, 'r') as file_input:
+            schedule_db = file_input.read()
             schedules = json.loads(schedule_db)
             for zone_id, zone_schedule in schedules.items():
 
@@ -126,5 +146,6 @@ class ControlSystem(EvohomeBase):
                 if self.hotwater and self.hotwater.zoneId == zone_id:
                     self.hotwater.set_schedule(json.dumps(zone_info))
                 else:
-                    self.zones_by_id[zone_id].set_schedule(json.dumps(zone_info))
+                    self.zones_by_id[zone_id].set_schedule(
+                        json.dumps(zone_info))
         print("Restored zone schedules from: %s" % filename)

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -36,7 +36,7 @@ class ControlSystem(EvohomeBase):
 
     def _set_status(self, mode, until=None):
 
-        headers = dict(self.client.headers())
+        headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
 
         if until is None:

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -5,6 +5,7 @@ from .zone import Zone
 from .hotwater import HotWater
 from .base import EvohomeBase, EvohomeClientInvalidPostData
 
+
 class ControlSystem(EvohomeBase):
 
     def __init__(self, client, location, gateway, data=None):
@@ -39,9 +40,9 @@ class ControlSystem(EvohomeBase):
         headers['Content-Type'] = 'application/json'
 
         if until is None:
-            data = {"SystemMode":mode,"TimeUntil":None,"Permanent":True}
+            data = {"SystemMode": mode, "TimeUntil": None, "Permanent": True}
         else:
-            data = {"SystemMode":mode,"TimeUntil":"%sT00:00:00Z" % until.strftime('%Y-%m-%d'),"Permanent":False}
+            data = {"SystemMode": mode, "TimeUntil": "%sT00:00:00Z" % until.strftime('%Y-%m-%d'), "Permanent": False}
 
         r = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureControlSystem/%s/mode' % self.systemId, data=json.dumps(data), headers=headers)
 
@@ -74,19 +75,17 @@ class ControlSystem(EvohomeBase):
 
         if self.hotwater:
             yield {'thermostat': 'DOMESTIC_HOT_WATER',
-                    'id': self.hotwater.dhwId,
-                    'name': '',
-                    'temp': self.hotwater.temperatureStatus['temperature'],
-                    'setpoint': ''
-                  }
+                   'id': self.hotwater.dhwId,
+                   'name': '',
+                   'temp': self.hotwater.temperatureStatus['temperature'],
+                   'setpoint': ''}
 
         for zone in self._zones:
             z = {'thermostat': 'EMEA_ZONE',
                  'id': zone.zoneId,
                  'name': zone.name,
                  'temp': None,
-                 'setpoint': zone.setpointStatus['targetHeatTemperature']
-                }
+                 'setpoint': zone.setpointStatus['targetHeatTemperature']}
             if zone.temperatureStatus['isAvailable']:
                 z['temp'] = zone.temperatureStatus['temperature']
             yield z
@@ -95,19 +94,19 @@ class ControlSystem(EvohomeBase):
         print("Backing up zone schedule to: %s" % (filename))
 
         schedules = {}
-        
+
         if self.hotwater:
             print("Retrieving DHW schedule: %s" % self.hotwater.zoneId)
             s = self.hotwater.schedule()
             schedules[self.hotwater.zoneId] = {'name': 'Domestic Hot Water', 'schedule': s}
-        
+
         for z in self._zones:
             zone_id = z.zoneId
             name = z.name
             print("Retrieving zone schedule: %s - %s" % (zone_id, name))
             s = z.schedule()
             schedules[zone_id] = {'name': name, 'schedule': s}
-            
+
         schedule_db = json.dumps(schedules, indent=4)
 
         with open(filename, 'w') as f:
@@ -121,12 +120,12 @@ class ControlSystem(EvohomeBase):
             schedule_db = f.read()
             schedules = json.loads(schedule_db)
             for zone_id, zone_schedule in schedules.items():
-                
+
                 name = zone_schedule['name']
                 zone_info = zone_schedule['schedule']
                 print("Restoring schedule for: %s - %s" % (zone_id, name))
-                
-                if self.hotwater and self.hotwater.zoneId==zone_id:
+
+                if self.hotwater and self.hotwater.zoneId == zone_id:
                     self.hotwater.set_schedule(json.dumps(zone_info))
                 else:
                     self.zones_by_id[zone_id].set_schedule(json.dumps(zone_info))

--- a/evohomeclient2/gateway.py
+++ b/evohomeclient2/gateway.py
@@ -1,7 +1,7 @@
 from .controlsystem import ControlSystem
 
-class Gateway(object):
 
+class Gateway(object):
 
     def __init__(self, client, location, data=None):
         self.client = client

--- a/evohomeclient2/gateway.py
+++ b/evohomeclient2/gateway.py
@@ -1,7 +1,9 @@
+"""Provides handling of a gateway"""
 from .controlsystem import ControlSystem
 
 
-class Gateway(object):
+class Gateway(object):  # pylint: disable=too-few-public-methods
+    """Provides handling of a gateway"""
 
     def __init__(self, client, location, data=None):
         self.client = client
@@ -12,6 +14,6 @@ class Gateway(object):
             self.__dict__.update(data['gatewayInfo'])
 
             for cs_data in data['temperatureControlSystems']:
-                cs = ControlSystem(client, location, self, cs_data)
-                self._control_systems.append(cs)
-                self.control_systems[cs.systemId] = cs
+                control_system = ControlSystem(client, location, self, cs_data)
+                self._control_systems.append(control_system)
+                self.control_systems[control_system.systemId] = control_system  # pylint: disable=no-member

--- a/evohomeclient2/hotwater.py
+++ b/evohomeclient2/hotwater.py
@@ -1,10 +1,12 @@
-import requests
+"""Provides handling of the hot water zone"""
 import json
+import requests
 
 from .zone import ZoneBase
 
 
 class HotWater(ZoneBase):
+    """Provides handling of the hot water zone"""
 
     def __init__(self, client, data=None):
         super(HotWater, self).__init__()
@@ -12,32 +14,38 @@ class HotWater(ZoneBase):
         self.zone_type = 'domesticHotWater'
         if data is not None:
             self.__dict__.update(data)
-            self.zoneId = self.dhwId
+            self.zoneId = self.dhwId  # pylint: disable=no-member
 
     def _set_dhw(self, data):
+        # pylint: disable=protected-access
         headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
-        url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/domesticHotWater/%s/state' % self.dhwId
+        url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/domesticHotWater/%s/state' % self.dhwId  # pylint: disable=no-member
 
-        r = requests.put(url, data=json.dumps(data), headers=headers)
+        response = requests.put(url, data=json.dumps(data), headers=headers)
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+            response.raise_for_status()
 
     def set_dhw_on(self, until=None):
+        """Sets the DHW on until a given time, or permanantly"""
         if until is None:
             data = {"State": "On", "Mode": "PermanentOverride", "UntilTime": None}
         else:
-            data = {"State": "On", "Mode": "TemporaryOverride", "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"State": "On", "Mode": "TemporaryOverride",
+                    "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_off(self, until=None):
+        """Sets the DHW off until a given time, or permanantly"""
         if until is None:
             data = {"State": "Off", "Mode": "PermanentOverride", "UntilTime": None}
         else:
-            data = {"State": "Off", "Mode": "TemporaryOverride", "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"State": "Off", "Mode": "TemporaryOverride",
+                    "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_auto(self):
+        """Sets the DHW to follow the schedule"""
         data = {"State": "", "Mode": "FollowSchedule", "UntilTime": None}
         self._set_dhw(data)

--- a/evohomeclient2/hotwater.py
+++ b/evohomeclient2/hotwater.py
@@ -15,7 +15,7 @@ class HotWater(ZoneBase):
             self.zoneId = self.dhwId
 
     def _set_dhw(self, data):
-        headers = dict(self.client.headers())
+        headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
         url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/domesticHotWater/%s/state' % self.dhwId
 

--- a/evohomeclient2/hotwater.py
+++ b/evohomeclient2/hotwater.py
@@ -3,6 +3,7 @@ import json
 
 from .zone import ZoneBase
 
+
 class HotWater(ZoneBase):
 
     def __init__(self, client, data=None):
@@ -25,18 +26,18 @@ class HotWater(ZoneBase):
 
     def set_dhw_on(self, until=None):
         if until is None:
-            data = {"State":"On","Mode":"PermanentOverride","UntilTime":None}
+            data = {"State": "On", "Mode": "PermanentOverride", "UntilTime": None}
         else:
-            data = {"State":"On","Mode":"TemporaryOverride","UntilTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"State": "On", "Mode": "TemporaryOverride", "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_off(self, until=None):
         if until is None:
-            data = {"State":"Off","Mode":"PermanentOverride","UntilTime":None}
+            data = {"State": "Off", "Mode": "PermanentOverride", "UntilTime": None}
         else:
-            data = {"State":"Off","Mode":"TemporaryOverride","UntilTime":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"State": "Off", "Mode": "TemporaryOverride", "UntilTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_dhw(data)
 
     def set_dhw_auto(self):
-        data =  {"State":"","Mode":"FollowSchedule","UntilTime":None}
+        data = {"State": "", "Mode": "FollowSchedule", "UntilTime": None}
         self._set_dhw(data)

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -2,6 +2,7 @@ from .gateway import Gateway
 from .base import EvohomeBase
 import requests
 
+
 class Location(EvohomeBase):
 
     def __init__(self, client, data=None):

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -20,7 +20,7 @@ class Location(EvohomeBase):
             self.status()
 
     def status(self):
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/status?includeTemperatureControlSystems=True' % self.locationId, headers=self.client.headers())
+        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/status?includeTemperatureControlSystems=True' % self.locationId, headers=self.client._headers())
 
         if r.status_code != requests.codes.ok:
             r.raise_for_status()

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -1,46 +1,54 @@
+"""Provides handling of a location"""
+import requests
 from .gateway import Gateway
 from .base import EvohomeBase
-import requests
 
 
-class Location(EvohomeBase):
+class Location(EvohomeBase):  # pylint: disable=too-few-public-methods
+    """Provides handling of a location"""
 
     def __init__(self, client, data=None):
         super(Location, self).__init__()
         self.client = client
         self._gateways = []
         self.gateways = {}
+        self.locationId = None  # pylint: disable=invalid-name
         if data is not None:
             self.__dict__.update(data['locationInfo'])
 
             for gw_data in data['gateways']:
                 gateway = Gateway(client, self, gw_data)
                 self._gateways.append(gateway)
-                self.gateways[gateway.gatewayId] = gateway
+                self.gateways[gateway.gatewayId] = gateway  # pylint: disable=no-member
             self.status()
 
     def status(self):
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/status?includeTemperatureControlSystems=True' % self.locationId, headers=self.client._headers())
+        """Retrieves the location status"""
+        response = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/location/%s/status?includeTemperatureControlSystems=True' %
+                                self.locationId,
+                                headers=self.client._headers())  # pylint: disable=protected-access
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+            response.raise_for_status()
 
-        data = self.client._convert(r.text)
+        # pylint: disable=protected-access
+        data = self.client._convert(response.text)
 
         # Now feed into other elements
-        for gw in data['gateways']:
-            gateway = self.gateways[gw['gatewayId']]
+        for gw_data in data['gateways']:
+            gateway = self.gateways[gw_data['gatewayId']]
 
-            for sys in gw["temperatureControlSystems"]:
+            for sys in gw_data["temperatureControlSystems"]:
                 system = gateway.control_systems[sys['systemId']]
 
-                system.__dict__.update({'systemModeStatus': sys['systemModeStatus'], 'activeFaults': sys['activeFaults']})
+                system.__dict__.update(
+                    {'systemModeStatus': sys['systemModeStatus'], 'activeFaults': sys['activeFaults']})
 
                 if 'dhw' in sys:
                     system.hotwater.__dict__.update(sys['dhw'])
 
-                for z in sys["zones"]:
-                    zone = system.zones[z['name']]
-                    zone.__dict__.update(z)
+                for zone_data in sys["zones"]:
+                    zone = system.zones[zone_data['name']]
+                    zone.__dict__.update(zone_data)
 
         return data

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -8,7 +8,7 @@ class ZoneBase(EvohomeBase):
         super(ZoneBase, self).__init__()
 
     def schedule(self):
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' % (self.zone_type, self.zoneId), headers=self.client.headers())
+        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' % (self.zone_type, self.zoneId), headers=self.client._headers())
 
         if r.status_code != requests.codes.ok:
             r.raise_for_status()
@@ -39,7 +39,7 @@ class ZoneBase(EvohomeBase):
         except ValueError as error:
             raise EvohomeClientInvalidPostData('zone_info must be valid JSON: ', error)
 
-        headers = dict(self.client.headers())
+        headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
         r = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' % (self.zone_type, self.zoneId), data=zone_info, headers=headers)
 
@@ -67,7 +67,7 @@ class Zone(ZoneBase):
 
     def _set_heat_setpoint(self, data):
         url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureZone/%s/heatSetpoint' % self.zoneId
-        headers = dict(self.client.headers())
+        headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
         r = requests.put(url, json.dumps(data), headers=headers)
 

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -1,17 +1,25 @@
+"""Provides handling of individual zones"""
 import json
 import requests
 from .base import EvohomeBase, EvohomeClientInvalidPostData
 
 
 class ZoneBase(EvohomeBase):
+    """Provides the base for Zones"""
+
     def __init__(self):
         super(ZoneBase, self).__init__()
+        self.name = ""
+        self.zoneId = ""  # pylint: disable=invalid-name
+        self.zone_type = ""
 
     def schedule(self):
-        r = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' % (self.zone_type, self.zoneId), headers=self.client._headers())
+        """Gets the schedule for the given zone"""
+        response = requests.get('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' %
+                                (self.zone_type, self.zoneId), headers=self.client._headers())  # pylint: disable=no-member,protected-access
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+            response.raise_for_status()
 
         mapping = [
             ('dailySchedules', 'DailySchedules'),
@@ -21,35 +29,40 @@ class ZoneBase(EvohomeBase):
             ('switchpoints', 'Switchpoints'),
             ('dhwState', 'DhwState'),
         ]
-        j = r.text
-        for f, t in mapping:
-            j = j.replace(f, t)
+        response_data = response.text
+        for from_val, to_val in mapping:
+            response_data = response_data.replace(from_val, to_val)
 
-        d = self._convert(j)
+        data = self._convert(response_data)
         # change the day name string to a number offset (0 = Monday)
-        for day_of_week, schedule in enumerate(d['DailySchedules']):
+        for day_of_week, schedule in enumerate(data['DailySchedules']):
             schedule['DayOfWeek'] = day_of_week
-        return d
+        return data
 
     def set_schedule(self, zone_info):
+        """Sets the schedule for this zone"""
         # must only POST json, otherwise server API handler raises exceptions
 
         try:
             json.loads(zone_info)
         except ValueError as error:
-            raise EvohomeClientInvalidPostData('zone_info must be valid JSON: ', error)
+            raise EvohomeClientInvalidPostData(
+                'zone_info must be valid JSON: ', error)
 
+        # pylint: disable=no-member,protected-access
         headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
-        r = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' % (self.zone_type, self.zoneId), data=zone_info, headers=headers)
+        response = requests.put('https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule' %
+                                (self.zone_type, self.zoneId), data=zone_info, headers=headers)
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+            response.raise_for_status()
 
-        return self._convert(r.text)
+        return self._convert(response.text)
 
 
 class Zone(ZoneBase):
+    """Provides the access to an individual zone"""
 
     def __init__(self, client, data=None):
         super(Zone, self).__init__()
@@ -59,21 +72,28 @@ class Zone(ZoneBase):
             self.__dict__.update(data)
 
     def set_temperature(self, temperature, until=None):
+        """Sets the temperature of the given zone"""
         if until is None:
-            data = {"HeatSetpointValue": temperature, "SetpointMode": "PermanentOverride", "TimeUntil": None}
+            data = {"HeatSetpointValue": temperature,
+                    "SetpointMode": "PermanentOverride", "TimeUntil": None}
         else:
-            data = {"HeatSetpointValue": temperature, "SetpointMode": "TemporaryOverride", "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"HeatSetpointValue": temperature, "SetpointMode": "TemporaryOverride",
+                    "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_heat_setpoint(data)
 
     def _set_heat_setpoint(self, data):
         url = 'https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureZone/%s/heatSetpoint' % self.zoneId
+
+        # pylint: disable=no-member,protected-access
         headers = dict(self.client._headers())
         headers['Content-Type'] = 'application/json'
-        r = requests.put(url, json.dumps(data), headers=headers)
+        response = requests.put(url, json.dumps(data), headers=headers)
 
-        if r.status_code != requests.codes.ok:
-            r.raise_for_status()
+        if response.status_code != requests.codes.ok:  # pylint: disable=no-member
+            response.raise_for_status()
 
-    def cancel_temp_override(self, *args, **kwargs):
-        data = {"HeatSetpointValue": 0.0, "SetpointMode": "FollowSchedule", "TimeUntil": None}
+    def cancel_temp_override(self):
+        """Cancels an override to the zone temperature"""
+        data = {"HeatSetpointValue": 0.0,
+                "SetpointMode": "FollowSchedule", "TimeUntil": None}
         self._set_heat_setpoint(data)

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -35,9 +35,9 @@ class ZoneBase(EvohomeBase):
         # must only POST json, otherwise server API handler raises exceptions
 
         try:
-            t1 = json.loads(zone_info)
-        except:
-            raise EvohomeClientInvalidPostData('zone_info must be JSON')
+            json.loads(zone_info)
+        except ValueError as error:
+            raise EvohomeClientInvalidPostData('zone_info must be valid JSON: ', error)
 
         headers = dict(self.client.headers())
         headers['Content-Type'] = 'application/json'

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -2,6 +2,7 @@ import json
 import requests
 from .base import EvohomeBase, EvohomeClientInvalidPostData
 
+
 class ZoneBase(EvohomeBase):
     def __init__(self):
         super(ZoneBase, self).__init__()
@@ -23,13 +24,13 @@ class ZoneBase(EvohomeBase):
         j = r.text
         for f, t in mapping:
             j = j.replace(f, t)
-            
+
         d = self._convert(j)
         # change the day name string to a number offset (0 = Monday)
         for day_of_week, schedule in enumerate(d['DailySchedules']):
             schedule['DayOfWeek'] = day_of_week
         return d
-        
+
     def set_schedule(self, zone_info):
         # must only POST json, otherwise server API handler raises exceptions
 
@@ -47,6 +48,7 @@ class ZoneBase(EvohomeBase):
 
         return self._convert(r.text)
 
+
 class Zone(ZoneBase):
 
     def __init__(self, client, data=None):
@@ -58,9 +60,9 @@ class Zone(ZoneBase):
 
     def set_temperature(self, temperature, until=None):
         if until is None:
-            data = {"HeatSetpointValue":temperature,"SetpointMode":"PermanentOverride","TimeUntil":None}
+            data = {"HeatSetpointValue": temperature, "SetpointMode": "PermanentOverride", "TimeUntil": None}
         else:
-            data = {"HeatSetpointValue":temperature,"SetpointMode":"TemporaryOverride","TimeUntil":until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+            data = {"HeatSetpointValue": temperature, "SetpointMode": "TemporaryOverride", "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
         self._set_heat_setpoint(data)
 
     def _set_heat_setpoint(self, data):
@@ -73,6 +75,5 @@ class Zone(ZoneBase):
             r.raise_for_status()
 
     def cancel_temp_override(self, *args, **kwargs):
-        data = {"HeatSetpointValue":0.0,"SetpointMode":"FollowSchedule","TimeUntil":None}
+        data = {"HeatSetpointValue": 0.0, "SetpointMode": "FollowSchedule", "TimeUntil": None}
         self._set_heat_setpoint(data)
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,10 @@
 [metadata]
 description-file = README.md
+
+[nosetests]
+with-coverage=true
+cover-package=evohomeclient
+cover-html=true
+cover-html-dir=htmlcov
+with-xunit=true
+xunit-file=test-reports/junit.xml

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,18 @@
 from setuptools import setup
 
 setup(
-	name = 'evohomeclient',
-	version = '0.2.8',
-	description = 'Python client for connecting to the Evohome webservice',
-	url = 'https://github.com/watchforstock/evohome-client/',
-	download_url = 'https://github.com/watchforstock/evohome-client/tarball/0.2.8',
-	author = 'Andrew Stock',
-	author_email = 'evohome@andrew-stock.com',
-	license = 'Apache 2',
-	classifiers = [
-		'Development Status :: 3 - Alpha',
-	],
-	keywords = ['evohome'],
-	packages = ['evohomeclient', 'evohomeclient2'],
-	install_requires = ['requests']
+    name='evohomeclient',
+    version='0.2.8',
+    description='Python client for connecting to the Evohome webservice',
+    url='https://github.com/watchforstock/evohome-client/',
+    download_url='https://github.com/watchforstock/evohome-client/tarball/0.2.8',
+    author='Andrew Stock',
+    author_email='evohome@andrew-stock.com',
+    license='Apache 2',
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+    ],
+    keywords=['evohome'],
+    packages=['evohomeclient', 'evohomeclient2'],
+    install_requires=['requests']
 )


### PR DESCRIPTION
The existing code has the following (rather useful) block that is executed during initialization:
```python
if debug = True:
    turn_debug_logging_on()
else:
    turn_debug_logging_off()
```

Turning debug logging on is useful, but not turning it on shouldn't mean that it be turned off. 

For example, I use this component in a smarthome platform, and it has a means to configure logging of it's components, libraries, etc. in a single log file.  The existing code overrules this behaviour.

Here, I am proposing:
```python
if debug = True:
    turn_debug_logging_on()
```

If `debug` is not `true`, then the debugging may still occur according to the expected behavior of [logger](https://docs.python.org/3/library/logging.html)

