### PR TITLE
Improve debug logging to expected behavior

### DIFF
--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -35,7 +35,8 @@ class EvohomeClient:
     """Provides a client to access the Honeywell Evohome system"""
     # pylint: disable=too-many-instance-attributes,too-many-arguments
 
-    def __init__(self, username, password, debug=False, user_data=None, hostname="https://tccna.honeywell.com"):
+    def __init__(self, username, password, debug=False, user_data=None,
+                 hostname="https://tccna.honeywell.com"):
         """Constructor. Takes the username and password for the service.
 
         If user_data is given then this will be used to try and reduce

--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -1,4 +1,7 @@
-"""evohomeclient is based on the original API for access to Evohome data"""
+"""evohomeclient2 provides a client for the oiginal Evohome API.
+
+   Further information at: https://evohome-client.readthedocs.io
+   """
 from __future__ import print_function
 
 import codecs
@@ -9,7 +12,8 @@ import sys
 import requests
 
 logging.basicConfig()
-REQUESTS_LOG = logging.getLogger("requests.packages.urllib3")
+_LOGGER = logging.getLogger(__name__)
+REQUESTS_LOGGER = logging.getLogger("requests.packages.urllib3")
 
 try:
     import http.client as http_client
@@ -53,15 +57,13 @@ class EvohomeClient:
         self.headers = {}
 
         if debug is True:
+            _LOGGER.setLevel(logging.DEBUG)
+            _LOGGER.debug("__init__(): Debug mode is explicitly enabled.")
+            REQUESTS_LOGGER.setLevel(logging.DEBUG)
+            REQUESTS_LOGGER.propagate = True
             http_client.HTTPConnection.debuglevel = 1
-            logging.getLogger(__name__).setLevel(logging.DEBUG)
-            REQUESTS_LOG.setLevel(logging.DEBUG)
-            REQUESTS_LOG.propagate = True
         else:
-            http_client.HTTPConnection.debuglevel = 0
-            logging.getLogger(__name__).setLevel(logging.INFO)
-            REQUESTS_LOG.setLevel(logging.INFO)
-            REQUESTS_LOG.propagate = False
+            _LOGGER.debug("__init__(): Debug mode was not explicitly enabled.")
 
     def _convert(self, content):
         return json.loads(self.reader(content)[0])

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -1,4 +1,7 @@
-"""Provides a client for the updated Evohome API"""
+"""evohomeclient2 provides a client for the updated Evohome API.
+
+   Further information at: https://evohome-client.readthedocs.io
+   """
 from __future__ import print_function
 from datetime import datetime, timedelta
 import requests

--- a/evohomeclient2/base.py
+++ b/evohomeclient2/base.py
@@ -2,8 +2,10 @@
 import json
 import codecs
 import logging
+
 logging.basicConfig()
-REQUESTS_LOG = logging.getLogger("requests.packages.urllib3")
+_LOGGER = logging.getLogger(__name__)
+REQUESTS_LOGGER = logging.getLogger("requests.packages.urllib3")
 
 try:
     import http.client as http_client
@@ -22,16 +24,14 @@ class EvohomeBase(object):  # pylint: disable=too-few-public-methods
     def __init__(self, debug=False):
         self.reader = codecs.getdecoder("utf-8")
 
-        if debug:
+        if debug is True:
+            _LOGGER.setLevel(logging.DEBUG)
+            _LOGGER.debug("__init__(): Debug mode is explicitly enabled.")
+            REQUESTS_LOGGER.setLevel(logging.DEBUG)
+            REQUESTS_LOGGER.propagate = True
             http_client.HTTPConnection.debuglevel = 1
-            logging.getLogger(__name__).setLevel(logging.DEBUG)
-            REQUESTS_LOG.setLevel(logging.DEBUG)
-            REQUESTS_LOG.propagate = True
         else:
-            http_client.HTTPConnection.debuglevel = 0
-            logging.getLogger(__name__).setLevel(logging.INFO)
-            REQUESTS_LOG.setLevel(logging.INFO)
-            REQUESTS_LOG.propagate = False
+            _LOGGER.debug("__init__(): Debug mode was not explicitly enabled.")
 
     def _convert(self, obj):  # pylint: disable=no-self-use
         return json.loads(obj)


### PR DESCRIPTION
The existing code has the following (rather useful) block that is executed during initialization:
```python
if debug = True:
    turn_debug_logging_on()
else:
    turn_debug_logging_off()
```

Turning debug logging on is useful, but _not_ turning it `on` shouldn't mean that it must be turned `off`. By default, such debugging is off anyway!

However, _forcing_ it to be off can be troublesome. For example, I use this component in a smarthome platform, and it has a means to configure logging of it's components, libraries, etc. in a single log file.  The existing code overrules this behaviour.

My experience is that although I have enabled logging for **evohomecleint**, it doesn't occur unless I also set `debug = True`, and then I get more logging than I expected.

Here, I am proposing:
```python
if debug = True:
    turn_debug_logging_on()
```

If `debug` is not `true`, then the debugging may still occur according to the expected behavior of [logger](https://docs.python.org/3/library/logging.html)

