### PR TITLE
Improve exception handling during _basic_login()

### DIFF
--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -133,12 +133,13 @@ class EvohomeClient(object):                                                    
 
         response = requests.post(url, data=payload, headers=HEADER_BASIC_AUTH)
 
-        if response.status_code != requests.codes.ok:                            # pylint: disable=no-member
-            if response.text:  # if there is a message, then raise with it
-                raise requests.HTTPError("Unable to obtain an Access Token, "
-                                         "response was: ", response.text)
-        else:  # raise all others
+        try:
             response.raise_for_status()
+        except requests.HTTPError as err:
+            msg = "Unable to obtain an Access Token"
+            if response.text:  # if there is a message, then raise with it
+                msg = msg + ", response was: " + response.text
+            raise Exception(msg)
 
         try:  # the access token _should_ be valid...
             # this may cause a ValueError
@@ -153,12 +154,12 @@ class EvohomeClient(object):                                                    
             self.refresh_token = response_json['refresh_token']
 
         except KeyError:
-            raise KeyError("Unable to obtain an Access Token, "
-                           "response was: ", response_json)
+            raise Exception("Unable to obtain an Access Token, "
+                            "response was: " + response_json)
 
         except ValueError:
-            raise ValueError("Unable to obtain an Access Token, "
-                             "response was: ", response.text)
+            raise Exception("Unable to obtain an Access Token, "
+                            "response was: " + response.text)
 
     def _get_location(self, location):
         if location is None:


### PR DESCRIPTION
A proposed fix to issue #85 

Both versions of **EvohomeClient** should behave consistently when handling `requests` exceptions and when producing error/warning messages, providing useful feedback where possible.

One core issue is that `raise_for_exception()` does not include `response.text` (or the JSON equivalent) - this is by design.

Another issue is that the RESTful API is undocumented, so we should be mindful that responses may not be as expected from (say) a review of **OAuth** documentation..

Basic approach: 
a) catch all authentication/authorization/session expiry errors & attempt to transparently fall back to re-authenticate (access_token -> refresh_token -> user credentials),  `raise`ing only if that fails (e.g. bad user credentials)
b) catch all `HTTPError`s to test if they have a response (usu. JSON), and subsequently `raise` them, _including_ that message
c) (blindly) raise anything else - using `raise_for_exception()`

Raising a `ValueError` or a `KeyError` is not consistent with that, but these exist a final checks of validity.
