### PR TITLE
correcting package name

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -15,7 +15,7 @@ Install the evohome client library:
 
 .. code-block:: none
 
-    pip install ./evohome-client
+    pip install evohomeclient
 
 Versions
 --------


### PR DESCRIPTION
The package evohome-client does not exists, evohomeclient does.