### PR TITLE
Allow system mode until with hours, minutes

### DIFF
--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -210,7 +210,7 @@ class EvohomeClient(object):  # pylint: disable=useless-object-inheritance
         else:
             data = {
                 "QuickAction": status,
-                "QuickActionNextTime": "%sT00:00:00Z" % until.strftime('%Y-%m-%d')
+                "QuickActionNextTime": until.strftime('%Y-%m-%dT%H:%M:%SZ')
             }
 
         response = self._do_request('put', url, json.dumps(data))

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -47,7 +47,7 @@ class ControlSystem(object):                                                    
         else:
             data = {
                 "SystemMode": mode,
-                "TimeUntil": "%sT00:00:00Z" % until.strftime('%Y-%m-%d'),
+                "TimeUntil": "%s:00Z" % until.strftime('%Y-%m-%dT%H:%M'),
                 "Permanent": False
             }
 

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -47,7 +47,7 @@ class ControlSystem(object):                                                    
         else:
             data = {
                 "SystemMode": mode,
-                "TimeUntil": "%s:00Z" % until.strftime('%Y-%m-%dT%H:%M'),
+                "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:%SZ'),
                 "Permanent": False
             }
 


### PR DESCRIPTION
The system **AutoWithEco** mode has an 'official' resolution of hours in the Controller UI, but _will_ work with minutes. Other modes, e.g. **Away**, have a resolution of days, but appears to work with (say) hours.

The client library rounds down all `TimeUntil`s for `_set_status()` to midnight, this precludes the full extent of the above functionality.

This is the fix - to remove the rounding.

I have not tested on this client, but it is a very simple fix, and the equivalent fix has been tested on **evohome-async**.