### PR TITLE
expose set_status() as a public member

### DIFF
--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -47,7 +47,7 @@ class ControlSystem(object):                                                    
         else:
             data = {
                 "SystemMode": mode,
-                "TimeUntil": "%sT00:00:00Z" % until.strftime('%Y-%m-%d'),
+                "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:00Z'),
                 "Permanent": False
             }
 

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -58,6 +58,10 @@ class ControlSystem(object):                                                    
         )
         response.raise_for_status()
 
+    def set_status(self, mode, until=None):
+        """Set the system to a mode, either indefinitely, or for a set time."""
+        self._set_status(mode, until)
+
     def set_status_normal(self):
         """Set the system into normal mode."""
         self._set_status("Auto")

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -47,7 +47,7 @@ class ControlSystem(object):                                                    
         else:
             data = {
                 "SystemMode": mode,
-                "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:00Z'),
+                "TimeUntil": "%sT00:00:00Z" % until.strftime('%Y-%m-%d'),
                 "Permanent": False
             }
 

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -82,7 +82,7 @@ class Zone(ZoneBase):
         else:
             data = {"SetpointMode": "TemporaryOverride",
                     "HeatSetpointValue": temperature,
-                    "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
+                    "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:00Z')}
 
         self._set_heat_setpoint(data)
 

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -82,7 +82,7 @@ class Zone(ZoneBase):
         else:
             data = {"SetpointMode": "TemporaryOverride",
                     "HeatSetpointValue": temperature,
-                    "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:00Z')}
+                    "TimeUntil": until.strftime('%Y-%m-%dT%H:%M:%SZ')}
 
         self._set_heat_setpoint(data)
 


### PR DESCRIPTION
A simple change to expose the `_set_status` as a public citizen, and provide that method as an alternative to the individual methods.

You may wish to simply rename `_set_status()` to `set_status()`.