### PR TITLE
Add timeout to requests calls

### DIFF
--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -58,6 +58,7 @@ class EvohomeClient(
         refresh_token=None,
         access_token=None,
         access_token_expires=None,
+        timeout=30,
     ):  # pylint: disable=too-many-arguments
         """Construct the EvohomeClient object."""
         if debug is True:
@@ -80,6 +81,8 @@ class EvohomeClient(
         self.refresh_token = refresh_token
         self.access_token = access_token
         self.access_token_expires = access_token_expires
+
+        self.timeout = timeout
 
         self.account_info = None
         self.locations = None
@@ -167,7 +170,7 @@ class EvohomeClient(
         }
         payload.update(credentials)  # merge the credentials into the payload
 
-        response = requests.post(url, data=payload, headers=HEADER_BASIC_AUTH)
+        response = requests.post(url, data=payload, headers=HEADER_BASIC_AUTH, timeout=self.timeout)
 
         try:
             response.raise_for_status()
@@ -225,7 +228,7 @@ class EvohomeClient(
 
         url = "https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount"
 
-        response = requests.get(url, headers=self._headers())
+        response = requests.get(url, headers=self._headers(), timeout=self.timeout)
         response.raise_for_status()
 
         self.account_info = response.json()
@@ -241,7 +244,7 @@ class EvohomeClient(
             % self.account_info["userId"]
         )
 
-        response = requests.get(url, headers=self._headers())
+        response = requests.get(url, headers=self._headers(), timeout=self.timeout)
         response.raise_for_status()
 
         self.installation_info = response.json()
@@ -251,7 +254,7 @@ class EvohomeClient(
         ][0]["systemId"]
 
         for loc_data in self.installation_info:
-            self.locations.append(Location(self, loc_data))
+            self.locations.append(Location(self, loc_data, self.timeout))
 
         return self.installation_info
 
@@ -263,7 +266,7 @@ class EvohomeClient(
             % self._get_location(location)
         )
 
-        response = requests.get(url, headers=self._headers())
+        response = requests.get(url, headers=self._headers(), timeout=self.timeout)
         response.raise_for_status()
 
         return response.json()
@@ -272,7 +275,7 @@ class EvohomeClient(
         """Return the details of the gateway."""
         url = "https://tccna.honeywell.com/WebAPI/emea/api/v1/gateway"
 
-        response = requests.get(url, headers=self._headers())
+        response = requests.get(url, headers=self._headers(), timeout=self.timeout)
         response.raise_for_status()
 
         return response.json()

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -60,6 +60,7 @@ class ControlSystem(
             "/temperatureControlSystem/%s/mode" % self.systemId,
             data=json.dumps(data),
             headers=headers,
+            timeout=self.location.timeout,
         )
         response.raise_for_status()
 

--- a/evohomeclient2/hotwater.py
+++ b/evohomeclient2/hotwater.py
@@ -9,8 +9,8 @@ from .zone import ZoneBase
 class HotWater(ZoneBase):
     """Provides handling of the hot water zone."""
 
-    def __init__(self, client, data):
-        super(HotWater, self).__init__(client)
+    def __init__(self, client, data, timeout=30):
+        super(HotWater, self).__init__(client, timeout)
 
         self.dhwId = None                                                        # pylint: disable=invalid-name
 
@@ -28,7 +28,7 @@ class HotWater(ZoneBase):
             "/domesticHotWater/%s/state" % self.dhwId
         )
 
-        response = requests.put(url, data=json.dumps(data), headers=headers)
+        response = requests.put(url, data=json.dumps(data), headers=headers, timeout=self.timeout)
         response.raise_for_status()
 
     def set_dhw_on(self, until=None):
@@ -73,6 +73,6 @@ class HotWater(ZoneBase):
             "domesticHotWater/%s/status?" % self.dhwId
         )
 
-        response = requests.get( url, headers=self.client._headers())
+        response = requests.get( url, headers=self.client._headers(), timeout=self.timeout)
         data = response.json()
         return data

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -9,9 +9,10 @@ class Location(
 ):  # pylint: disable=too-few-public-methods,useless-object-inheritance
     """Provide handling of a location."""
 
-    def __init__(self, client, data=None):
+    def __init__(self, client, data=None, timeout=30):
         """Initialise the class."""
         self.client = client
+        self.timeout = timeout
         self._gateways = []
         self.gateways = {}
         self.locationId = None  # pylint: disable=invalid-name
@@ -34,6 +35,7 @@ class Location(
             "location/%s/status?includeTemperatureControlSystems=True"
             % self.locationId,
             headers=self.client._headers(),
+            timeout=self.timeout,
         )
         response.raise_for_status()
         data = response.json()

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -7,9 +7,10 @@ import requests
 class ZoneBase(object):  # pylint: disable=useless-object-inheritance
     """Provide the base for Zones."""
 
-    def __init__(self, client):
+    def __init__(self, client, timeout=30):
         """Initialise the class."""
         self.client = client
+        self.timeout = timeout
         self.name = None
         self.zoneId = None  # pylint: disable=invalid-name
         self.zone_type = None
@@ -21,6 +22,7 @@ class ZoneBase(object):  # pylint: disable=useless-object-inheritance
             "https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule"
             % (self.zone_type, self.zoneId),
             headers=self.client._headers(),
+            timeout=self.timeout,
         )
         response.raise_for_status()
 
@@ -61,6 +63,7 @@ class ZoneBase(object):  # pylint: disable=useless-object-inheritance
             % (self.zone_type, self.zoneId),
             data=zone_info,
             headers=headers,
+            timeout=self.timeout,
         )
         response.raise_for_status()
 
@@ -105,7 +108,7 @@ class Zone(ZoneBase):
         headers = dict(self.client._headers())
         headers["Content-Type"] = "application/json"
 
-        response = requests.put(url, json.dumps(data), headers=headers)
+        response = requests.put(url, json.dumps(data), headers=headers, timeout=self.timeout)
         response.raise_for_status()
 
     def cancel_temp_override(self):


### PR DESCRIPTION
Timeouts are important. As the [requests documentation](https://requests.readthedocs.io/en/master/user/quickstart/) states: 
> Nearly all production code should use this parameter in nearly all requests. Failure to do so can cause your program to hang indefinitely.

I've seen the Honeywell servers behave erratically, causing EvohomeClient() to hang indefinitely. Adding timeouts should help in that situation.