### PR TITLE
Add setpointmode and setpointend to zone_info

### DIFF
--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -113,6 +113,7 @@ class ControlSystem(
                 "setpoint": "",
                 "setpointmode": "",
                 "setpointend": "1970-01-01T00:00:00Z",
+                "activefaults": self.hotwater.activeFaults,
             }
 
         for zone in self._zones:
@@ -124,6 +125,7 @@ class ControlSystem(
                 "setpoint": zone.setpointStatus["targetHeatTemperature"],
                 "setpointmode": zone.setpointStatus["setpointMode"],
                 "setpointend": "1970-01-01T00:00:00Z",
+                "activefaults": zone.activeFaults,
             }
 
             if zone.temperatureStatus["isAvailable"]:

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -111,6 +111,8 @@ class ControlSystem(
                 "name": "",
                 "temp": self.hotwater.temperatureStatus["temperature"],
                 "setpoint": "",
+                "setpointmode": "",
+                "setpointend": "1970-01-01T00:00:00Z",
             }
 
         for zone in self._zones:
@@ -120,10 +122,14 @@ class ControlSystem(
                 "name": zone.name,
                 "temp": None,
                 "setpoint": zone.setpointStatus["targetHeatTemperature"],
+                "setpointmode": zone.setpointStatus["setpointMode"],
+                "setpointend": "1970-01-01T00:00:00Z",
             }
 
             if zone.temperatureStatus["isAvailable"]:
                 zone_info["temp"] = zone.temperatureStatus["temperature"]
+            if zone.setpointStatus.get("until"):
+                zone_info["setpointend"] = zone.setpointStatus["until"]
             yield zone_info
 
     def zone_schedules_backup(self, filename):


### PR DESCRIPTION
The Evohome API returns "setpointMode" and "until" which are both useful to store in zone_info.