### PR TITLE
Change tccna.honeywell.com to tccna.resideo.com

### DIFF
--- a/evohomeclient/__init__.py
+++ b/evohomeclient/__init__.py
@@ -38,7 +38,7 @@ class EvohomeClient(object):  # pylint: disable=useless-object-inheritance
         password,
         debug=False,
         user_data=None,
-        hostname="https://tccna.honeywell.com",
+        hostname="https://tccna.resideo.com",
     ):
         """Take the username and password for the service.
 

--- a/evohomeclient2/__init__.py
+++ b/evohomeclient2/__init__.py
@@ -160,7 +160,7 @@ class EvohomeClient(
         )
 
     def _obtain_access_token(self, credentials):
-        url = "https://tccna.honeywell.com/Auth/OAuth/Token"
+        url = "https://tccna.resideo.com/Auth/OAuth/Token"
         payload = {
             "Content-Type": "application/x-www-form-urlencoded; charset=utf-8",
             "Host": "rs.alarmnet.com/",
@@ -226,7 +226,7 @@ class EvohomeClient(
         """Return the user account information."""
         self.account_info = None
 
-        url = "https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount"
+        url = "https://tccna.resideo.com/WebAPI/emea/api/v1/userAccount"
 
         response = requests.get(url, headers=self._headers(), timeout=self.timeout)
         response.raise_for_status()
@@ -239,7 +239,7 @@ class EvohomeClient(
         self.locations = []
 
         url = (
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1/location"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1/location"
             "/installationInfo?userId=%s&includeTemperatureControlSystems=True"
             % self.account_info["userId"]
         )
@@ -261,7 +261,7 @@ class EvohomeClient(
     def full_installation(self, location=None):
         """Return the full details of the installation."""
         url = (
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1/location"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1/location"
             "/%s/installationInfo?includeTemperatureControlSystems=True"
             % self._get_location(location)
         )
@@ -273,7 +273,7 @@ class EvohomeClient(
 
     def gateway(self):
         """Return the details of the gateway."""
-        url = "https://tccna.honeywell.com/WebAPI/emea/api/v1/gateway"
+        url = "https://tccna.resideo.com/WebAPI/emea/api/v1/gateway"
 
         response = requests.get(url, headers=self._headers(), timeout=self.timeout)
         response.raise_for_status()

--- a/evohomeclient2/controlsystem.py
+++ b/evohomeclient2/controlsystem.py
@@ -56,7 +56,7 @@ class ControlSystem(
             }
 
         response = requests.put(
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1"
             "/temperatureControlSystem/%s/mode" % self.systemId,
             data=json.dumps(data),
             headers=headers,

--- a/evohomeclient2/hotwater.py
+++ b/evohomeclient2/hotwater.py
@@ -24,7 +24,7 @@ class HotWater(ZoneBase):
         headers = dict(self.client._headers())                                   # pylint: disable=protected-access
         headers['Content-Type'] = 'application/json'
         url = (
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1"
             "/domesticHotWater/%s/state" % self.dhwId
         )
 
@@ -69,7 +69,7 @@ class HotWater(ZoneBase):
     def get_dhw_state(self):
         """Gets the DHW state."""
         url = (
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1/"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1/"
             "domesticHotWater/%s/status?" % self.dhwId
         )
 

--- a/evohomeclient2/location.py
+++ b/evohomeclient2/location.py
@@ -31,7 +31,7 @@ class Location(
         """Retrieve the location status."""
         # pylint: disable=protected-access
         response = requests.get(
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1/"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1/"
             "location/%s/status?includeTemperatureControlSystems=True"
             % self.locationId,
             headers=self.client._headers(),

--- a/evohomeclient2/tests.py
+++ b/evohomeclient2/tests.py
@@ -135,22 +135,22 @@ GATEWAY_RESPONSE = """
 def test_user_account(mock):  # pylint: disable=invalid-name
     """test that user account is successful"""
     mock.post(
-        "https://tccna.honeywell.com/Auth/OAuth/Token",
+        "https://tccna.resideo.com/Auth/OAuth/Token",
         status_code=200,
         text=AUTH_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/userAccount",
         status_code=200,
         text=USER_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
         status_code=200,
         text=INSTALLATION_DATA,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
         status_code=200,
         text=LOCATION_DATA,
     )
@@ -167,22 +167,22 @@ def test_user_account(mock):  # pylint: disable=invalid-name
 def test_temperatures(mock):  # pylint: disable=invalid-name
     """test that user account is successful"""
     mock.post(
-        "https://tccna.honeywell.com/Auth/OAuth/Token",
+        "https://tccna.resideo.com/Auth/OAuth/Token",
         status_code=200,
         text=AUTH_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/userAccount",
         status_code=200,
         text=USER_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
         status_code=200,
         text=INSTALLATION_DATA,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
         status_code=200,
         text=LOCATION_DATA,
     )
@@ -197,27 +197,27 @@ def test_temperatures(mock):  # pylint: disable=invalid-name
 def test_gateway(mock):  # pylint: disable=invalid-name
     """test that user account is successful"""
     mock.post(
-        "https://tccna.honeywell.com/Auth/OAuth/Token",
+        "https://tccna.resideo.com/Auth/OAuth/Token",
         status_code=200,
         text=AUTH_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/userAccount",
         status_code=200,
         text=USER_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
         status_code=200,
         text=INSTALLATION_DATA,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
         status_code=200,
         text=LOCATION_DATA,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/gateway",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/gateway",
         status_code=200,
         text=GATEWAY_RESPONSE,
     )
@@ -231,27 +231,27 @@ def test_gateway(mock):  # pylint: disable=invalid-name
 def test_single_settings(mock):
     """Test can change different statuses"""
     mock.post(
-        "https://tccna.honeywell.com/Auth/OAuth/Token",
+        "https://tccna.resideo.com/Auth/OAuth/Token",
         status_code=200,
         text=AUTH_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/userAccount",
         status_code=200,
         text=USER_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
         status_code=200,
         text=INSTALLATION_DATA,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
         status_code=200,
         text=LOCATION_DATA,
     )
     mock.put(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureControlSystem/sysId/mode",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/temperatureControlSystem/sysId/mode",
         status_code=200,
         text="",
     )
@@ -270,27 +270,27 @@ def test_single_settings(mock):
 def test_multi_zone_failure(mock):
     """Confirm that exception is thrown for multiple locations"""
     mock.post(
-        "https://tccna.honeywell.com/Auth/OAuth/Token",
+        "https://tccna.resideo.com/Auth/OAuth/Token",
         status_code=200,
         text=AUTH_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/userAccount",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/userAccount",
         status_code=200,
         text=USER_RESPONSE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/installationInfo?userId=userId&includeTemperatureControlSystems=True",
         status_code=200,
         text=INSTALLATION_DATA_MULTIPLE,
     )
     mock.get(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/location/locationId/status?includeTemperatureControlSystems=True",
         status_code=200,
         text=LOCATION_DATA_MULTIPLE,
     )
     mock.put(
-        "https://tccna.honeywell.com/WebAPI/emea/api/v1/temperatureControlSystem/sysId/mode",
+        "https://tccna.resideo.com/WebAPI/emea/api/v1/temperatureControlSystem/sysId/mode",
         status_code=200,
         text="",
     )

--- a/evohomeclient2/zone.py
+++ b/evohomeclient2/zone.py
@@ -19,7 +19,7 @@ class ZoneBase(object):  # pylint: disable=useless-object-inheritance
         """Get the schedule for the given zone."""
         # pylint: disable=protected-access
         response = requests.get(
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1/%s/%s/schedule"
             % (self.zone_type, self.zoneId),
             headers=self.client._headers(),
             timeout=self.timeout,
@@ -59,7 +59,7 @@ class ZoneBase(object):  # pylint: disable=useless-object-inheritance
         headers["Content-Type"] = "application/json"
 
         response = requests.put(
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1/%s/%s/schedule"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1/%s/%s/schedule"
             % (self.zone_type, self.zoneId),
             data=zone_info,
             headers=headers,
@@ -101,7 +101,7 @@ class Zone(ZoneBase):
     def _set_heat_setpoint(self, data):
         # pylint: disable=protected-access
         url = (
-            "https://tccna.honeywell.com/WebAPI/emea/api/v1"
+            "https://tccna.resideo.com/WebAPI/emea/api/v1"
             "/temperatureZone/%s/heatSetpoint" % self.zoneId
         )
 


### PR DESCRIPTION
Today my log was filled with these messages:
```
Dec 12 20:00:05 nasty evohome-exporter.py[2811116]: WARNING:urllib3.connection:Certificate did not match expected hostname: tccna.honeywell.com. Certificate: {'subject': ((('countryName', 'US'),), (('stateOrProvinceName', 'Arizona'),), (('localityName', 'Scottsdale'),), (('organizationName', 'Resideo Technologies, Inc.'),), (('commonName', 'TCCNA.resideo.com'),)), 'issuer': ((('countryName', 'US'),), (('organizationName', 'DigiCert Inc'),), (('organizationalUnitName', 'www.digicert.com'),), (('commonName', 'DigiCert SHA2 High Assurance Server CA'),)), 'version': 3, 'serialNumber': '0C90B56510E4A7BED352C85BE8BABAB0', 'notBefore': 'Nov 20 00:00:00 2024 GMT', 'notAfter': 'Dec 21 23:59:59 2025 GMT', 'subjectAltName': (('DNS', 'TCCNA.resideo.com'), ('DNS', 'TCCEU.resideo.com'), ('DNS', 'TCCAP.resideo.com'), ('DNS', 'TCCNAS.resideo.com'), ('DNS', 'TCCEUS.resideo.com'), ('DNS', 'TCCAPS.resideo.com')), 'OCSP': ('http://ocsp.digicert.com',), 'caIssuers': ('http://cacerts.digicert.com/DigiCertSHA2HighAssuranceServerCA.crt',), 'crlDistributionPoints': ('http://crl3.digicert.com/sha2-ha-server-g6.crl', 'http://crl4.digicert.com/sha2-ha-server-g6.crl')}
```

It seems the new hostname for the EvoHome API now is `tccna.resideo.com`. Applying this patched fixed it for me.